### PR TITLE
feat(openrtb): Adds support for other JSON codec libraries.

### DIFF
--- a/openrtb/.gitignore
+++ b/openrtb/.gitignore
@@ -1,0 +1,1 @@
+*_easyjson.go

--- a/openrtb/Makefile
+++ b/openrtb/Makefile
@@ -1,0 +1,11 @@
+GO_IMAGE=vungle/golang
+DOCKER_GOPATH = $(shell docker run --rm $(GO_IMAGE) /bin/bash -c 'echo $$GOPATH')
+GO_WORKDIR = $(DOCKER_GOPATH)/src/github.com/Vungle/vungo/openrtb
+
+genfiles:
+	@find . -name "*_easyjson.go" -type f -delete
+	@docker run --rm \
+		-v $$(pwd):$(GO_WORKDIR) \
+		-w $(GO_WORKDIR) \
+		$(GO_IMAGE) \
+		/bin/bash -c 'go get -u github.com/mailru/easyjson/... && go generate'

--- a/openrtb/application.go
+++ b/openrtb/application.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Application struct {
 	Id string `json:"id"`
 

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -2,6 +2,8 @@ package openrtb
 
 import "encoding/json"
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Bid struct {
 	Id string `json:"id"`
 

--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -2,10 +2,12 @@ package openrtb
 
 import "fmt"
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type BidRequest struct {
 	Id string `json:"id"`
 
-	Impressions []*Impression `json:"imp,omitempty"`
+	Impressions []*Impression `json:"imp"`
 
 	// No Site(site).
 

--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -8,6 +8,8 @@ import (
 
 var emptyBid BidResponse
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type BidResponse struct {
 	Id string `json:"id"`
 

--- a/openrtb/device.go
+++ b/openrtb/device.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Device struct {
 	BrowserUserAgent     string         `json:"ua,omitempty"`
 	Geo                  *Geo           `json:"geo,omitempty"`

--- a/openrtb/geo.go
+++ b/openrtb/geo.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Geo struct {
 	Latitude  float64 `json:"lat,omitempty"`
 	Longitude float64 `json:"lon,omitempty"`

--- a/openrtb/impression.go
+++ b/openrtb/impression.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Impression struct {
 	Id string `json:"id"`
 

--- a/openrtb/openrtbutil/client.go
+++ b/openrtb/openrtbutil/client.go
@@ -2,7 +2,6 @@ package openrtbutil
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"log"
@@ -50,6 +49,7 @@ var DefaultClient = NewClient(nil)
 // Client also provides an embeddable log.Logger hook for capturing internal states during the
 // transactions; although most states are revealed via the returned error as well.
 type Client struct {
+	Decoder
 	*log.Logger
 
 	hc *http.Client
@@ -170,7 +170,7 @@ func (c *Client) handleNoBid(r *http.Response) error {
 
 func (c *Client) decode(body io.Reader) (*openrtb.BidResponse, error) {
 	br := &openrtb.BidResponse{}
-	if err := json.NewDecoder(body).Decode(br); err != nil {
+	if err := c.DecodeToReader(body, br); err != nil {
 		return nil, err
 	}
 
@@ -224,7 +224,8 @@ func NewClient(l *log.Logger) *Client {
 	}
 
 	return &Client{
-		Logger: l,
-		hc:     defaultHttpClient,
+		Decoder: DefaultDecoder,
+		Logger:  l,
+		hc:      defaultHttpClient,
 	}
 }

--- a/openrtb/openrtbutil/client_functional_test.go
+++ b/openrtb/openrtbutil/client_functional_test.go
@@ -82,7 +82,7 @@ func TestClientDoShouldNotOverrideExistingOpenRtbHeaders(t *testing.T) {
 		Id: "br-with-custom-header",
 	}
 
-	req, err := openrtbutil.NewRequest(ctx, br, ts.URL)
+	req, err := openrtbutil.NewRequest(ctx, br, ts.URL, nil)
 	if err != nil {
 		t.Fatal("Cannot create a bid request: ", err)
 	}
@@ -199,7 +199,7 @@ func TestClientDoShouldRespondNoBid(t *testing.T) {
 			Id: "br-for-no-bid",
 		}
 
-		req, err := openrtbutil.NewRequest(ctx, br, ts.URL)
+		req, err := openrtbutil.NewRequest(ctx, br, ts.URL, nil)
 		if err != nil {
 			t.Fatal("Cannot create a bid request: ", err)
 		}

--- a/openrtb/openrtbutil/client_test.go
+++ b/openrtb/openrtbutil/client_test.go
@@ -26,7 +26,7 @@ func MakeSimpleRequest(t *testing.T, url string) (*Response, error) {
 		Id: "没%创%意%真%可%怕",
 	}
 
-	req, err := NewRequest(ctx, br, url)
+	req, err := NewRequest(ctx, br, url, nil)
 	if err != nil {
 		t.Fatal("Cannot create a bid request: ", err)
 	}
@@ -140,7 +140,7 @@ func TestClientDoShouldDiscardResidualOnInvalidHttpResponse(t *testing.T) {
 			Id: "br-for-no-bid",
 		}
 
-		req, err := NewRequest(ctx, br, ts.URL)
+		req, err := NewRequest(ctx, br, ts.URL, nil)
 		if err != nil {
 			t.Fatal("Cannot create a bid request: ", err)
 		}

--- a/openrtb/openrtbutil/decoder.go
+++ b/openrtb/openrtbutil/decoder.go
@@ -1,0 +1,23 @@
+package openrtbutil
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// DefaultDecoder provides a standard default implementation of the Decoder.
+var DefaultDecoder = stdDecoder{}
+
+// Decoder type decodes an OpenRTB entity from io.Reader stream for processing by services like
+// ad exchange.
+type Decoder interface {
+	// DecodeToReader method decodes an OpenRTB entity from the given io.Reader stream.
+	DecodeToReader(io.Reader, interface{}) error
+}
+
+// stdDecoder implements the Decoder interface and provides a standard implementation.
+type stdDecoder struct{}
+
+func (d stdDecoder) DecodeToReader(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}

--- a/openrtb/openrtbutil/encoder.go
+++ b/openrtb/openrtbutil/encoder.go
@@ -1,0 +1,32 @@
+package openrtbutil
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// DefaultEncoder provides a standard default implementation of the Encoder.
+var DefaultEncoder = stdEncoder{}
+
+// Encoder type encodes an object for OpenRTB communication.
+type Encoder interface {
+	// EncodeToWriter method encodes the given object into an io.Writer stream.
+	EncodeToWriter(io.Writer, interface{}) error
+
+	// EncodeToResponseWriter method encodes the given object into an http.ResponseWriter stream. The
+	// implementation is responsible for properly configuring the underlying HTTP protocol, e.g.
+	// setting the correct Content-Length.
+	EncodeToResponseWriter(http.ResponseWriter, interface{}) error
+}
+
+// stdEncoder implements an Encoder interface and provides a standard implementation.
+type stdEncoder struct{}
+
+func (e stdEncoder) EncodeToWriter(w io.Writer, v interface{}) error {
+	return json.NewEncoder(w).Encode(v)
+}
+
+func (e stdEncoder) EncodeToResponseWriter(w http.ResponseWriter, v interface{}) error {
+	return json.NewEncoder(w).Encode(v)
+}

--- a/openrtb/openrtbutil/example_test.go
+++ b/openrtb/openrtbutil/example_test.go
@@ -23,7 +23,7 @@ func ExampleClient() {
 
 	endpoint := "http://127.0.0.1:8080/requestBid"
 
-	req, err := openrtbutil.NewRequest(ctx, br, endpoint)
+	req, err := openrtbutil.NewRequest(ctx, br, endpoint, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/openrtb/openrtbutil/openrtbutil.go
+++ b/openrtb/openrtbutil/openrtbutil.go
@@ -13,7 +13,7 @@ import (
 // An optional client can be provided; otherwise, a sane default client will be used to perform the
 // bid request.
 func RequestBid(ctx context.Context, br *openrtb.BidRequest, endpoint string, c *Client) (*Response, error) {
-	req, err := NewRequest(ctx, br, endpoint)
+	req, err := NewRequest(ctx, br, endpoint, DefaultEncoder)
 	if err != nil {
 		return nil, err
 	}

--- a/openrtb/openrtbutil/request_test.go
+++ b/openrtb/openrtbutil/request_test.go
@@ -54,7 +54,7 @@ func TestNewRequestError(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("Testing %d...", i)
 
-		_, err := openrtbutil.NewRequest(context.Background(), test.br, test.endpoint)
+		_, err := openrtbutil.NewRequest(context.Background(), test.br, test.endpoint, nil)
 		if err == nil {
 			t.Error("An error should have occurred.")
 			continue

--- a/openrtb/publisher.go
+++ b/openrtb/publisher.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Publisher struct {
 	Id string `json:"id"`
 

--- a/openrtb/regulation.go
+++ b/openrtb/regulation.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Regulation struct {
 	IsCoppaCompliant NumericBool `json:"coppa,omitempty"`
 

--- a/openrtb/seatbid.go
+++ b/openrtb/seatbid.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type SeatBid struct {
 	Bids  []*Bid `json:"bid,omitempty"`
 	Seat  string `json:"seat,omitempty"`

--- a/openrtb/user.go
+++ b/openrtb/user.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type User struct {
 	Id string `json:"id"`
 

--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -1,5 +1,7 @@
 package openrtb
 
+//go:generate easyjson $GOFILE
+//easyjson:json
 type Video struct {
 	MimeTypes   []string `json:"mimes"`
 	MinDuration int      `json:"minduration"`


### PR DESCRIPTION
# What

- Adds `Encoder` and `Decoder` interface so that the `openrtbutil` package can support other JSON codec libraries other than the stdlib one;
- Adds `Makefile` for creating [easyjson](mailru/easyjson) marshal/unmarshal interfaces;
- Adds `easyjson` specified docstring to OpenRTB entities.

Partially fixes Vungle/jaeger#355.