### PR TITLE
fix(openrtb): Make device boolean fields: dnt, lmt, js optional

### DIFF
--- a/openrtb/device.go
+++ b/openrtb/device.go
@@ -5,8 +5,8 @@ package openrtb
 type Device struct {
 	BrowserUserAgent     string         `json:"ua,omitempty"`
 	Geo                  *Geo           `json:"geo,omitempty"`
-	HasDoNotTrack        NumericBool    `json:"dnt,omitempty"`
-	HasLimitedAdTracking NumericBool    `json:"lmt,omitempty"`
+	HasDoNotTrack        *NumericBool   `json:"dnt,omitempty"`
+	HasLimitedAdTracking *NumericBool   `json:"lmt,omitempty"`
 	Ip                   string         `json:"ip,omitempty"`
 	Ipv6                 string         `json:"ipv6,omitempty"`
 	Type                 DeviceType     `json:"devicetype,omitempty"`
@@ -19,7 +19,7 @@ type Device struct {
 	Width                int            `json:"w,omitempty"`
 	Ppi                  int            `json:"ppi,omitempty"`
 	PixelRatio           float64        `json:"pxratio,omitempty"`
-	SupportsJavaScript   NumericBool    `json:"js,omitempty"`
+	SupportsJavaScript   *NumericBool   `json:"js,omitempty"`
 	FlashVersion         string         `json:"flashver,omitempty"`
 	Language             string         `json:"language,omitempty"`
 	Carrier              string         `json:"carrier,omitempty"`

--- a/openrtb/regulation.go
+++ b/openrtb/regulation.go
@@ -3,7 +3,7 @@ package openrtb
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Regulation struct {
-	IsCoppaCompliant NumericBool `json:"coppa,omitempty"`
+	IsCoppaCompliant *NumericBool `json:"coppa,omitempty"`
 
 	// No Extension(ext).
 }


### PR DESCRIPTION
# What

Exchange cannot determine the real value of boolean-like fields on device level: `dnt`, `lmt`, and `js` as they may be omitted from the device. Hence, it's best for exchange to pass along the raw information instead of interpreting missing information.

