### PR TITLE
feat(openrtb): Updates custom no-bid reasons

### DIFF
--- a/openrtb/export_test.go
+++ b/openrtb/export_test.go
@@ -1,0 +1,9 @@
+package openrtb
+
+// NoBidReasonSections contains a mapping of starting no-bid reason to ending no-bid reasons of each
+// section that is offered in nobidreason.go.
+var NoBidReasonSections = map[NoBidReason]NoBidReason{
+	NO_BID_UNKNOWN:              lastOpenrtbNoBidReason,
+	NO_BID_RESPONSE_TIMEOUT:     lastExchangeNoBidReason,
+	NO_BID_VUNGLE_NO_CANDIDATES: lastVungleNoBidReason,
+}

--- a/openrtb/nobidreason.go
+++ b/openrtb/nobidreason.go
@@ -14,8 +14,11 @@ func (n NoBidReason) String() string {
 	return name
 }
 
-// These NoBidReasons are defined by openrtb.
-// NOTE: Don't rearrange these. Add new ones to the bottom, above lastOpenrtbNoBidReason. When you add one, also add it to NO_BID_REASON_NAMES.
+// Standard no-bid reasons specified by OpenRTB 2.3.1.
+// See http://www.iab.net/media/file/OpenRTB_API_Specification_Version_2_3_1.pdf.
+//
+// NOTE: Don't rearrange the order. Add new ones to the bottom, above lastOpenrtbNoBidReason, as
+// well as to NO_BID_REASON_NAMES.
 const (
 	NO_BID_UNKNOWN NoBidReason = iota
 	NO_BID_TECHNICAL_ERROR
@@ -31,33 +34,61 @@ const (
 	lastOpenrtbNoBidReason
 )
 
-// These NoBidReasons are not in openrtb, but can happen when there is a problem with a bid request.
-// NOTE: Don't rearrange these. Add new ones to the bottom, above lastOpenrtbNoBidReason. When you add one, also add it to NO_BID_REASON_NAMES.
+// Custom no-bid reasons reserved for an exchange server, from 10000 - 10999.
+//
+// NOTE: Don't rearrange the order. Add new ones to the bottom, above lastExchangeNoBidReason, as
+// well as to NO_BID_REASON_NAMES.
 const (
+	// NO_BID_RESPONSE_TIMEOUT signals when the exchange server takes too long to receive a bid
+	// response.
 	NO_BID_RESPONSE_TIMEOUT NoBidReason = 10000 + iota
+
+	// NO_BID_REQUEST_ERROR signals when there's an error while the exchange serves tries to send a
+	// bid request.
 	NO_BID_REQUEST_ERROR
+
+	// NO_BID_REQUEST_ERROR signals when the bid response contains no content, e.g., HTTP 204, or
+	// HTTP 200 with no body.
 	NO_BID_HTTP_NO_CONTENT
+
+	// NO_BID_NON_STANDARD_HTTP_STATUS signals when the bidder responded with any other HTTP status
+	// beyond the standard OpenRTB protocol.
 	NO_BID_NON_STANDARD_HTTP_STATUS
+
+	// NO_BID_INVALID_HTTP_HEADER signals when the bidder responded with invalid HTTP headers, e.g.,
+	// when the X-Openrtb-Version is missing.
 	NO_BID_INVALID_HTTP_HEADER
+
+	// NO_BID_MALFORMATTED_PAYLOAD signals when the bidder responded with malformatted body payload.
 	NO_BID_MALFORMATTED_PAYLOAD
+
+	// NO_BID_BELOW_FLOOR signals when the bidder participated in auction, but the price is too low.
 	NO_BID_BELOW_FLOOR
+
+	// NO_BID_INVALID_CONTENT signals when the bid response is invalid for the originating bid
+	// request, e.g., when the bid response ID does not match with that of the bid request.
 	NO_BID_INVALID_CONTENT
 	// Add new entries here.
 
-	lastNonOpenrtbNoBidReason
+	lastExchangeNoBidReason
 )
 
-// FIRST_OPENRTB_NO_BID_REASON is a marker for the first element of the openrtb NoBidReason constants.
-const FIRST_OPENRTB_NO_BID_REASON = NO_BID_UNKNOWN
+// Custom no-bid reasons reserved by Vungle DSP, from 11000 - 11999.
+//
+// NOTE: Don't rearrange the order. Add new ones to the bottom, above lastVungleNoBidReason, as
+// well as to NO_BID_REASON_NAMES.
+const (
+	// NO_BID_VUNGLE_NO_CANDIDATES signals exchange server that a no-bid is due to no viable ad
+	// candidates.
+	NO_BID_VUNGLE_NO_CANDIDATES NoBidReason = 11000 + iota
 
-// LAST_OPENRTB_NO_BID_REASON is a marker for the last element of the openrtb NoBidReason constants.
-const LAST_OPENRTB_NO_BID_REASON = lastOpenrtbNoBidReason
+	// NO_BID_VUNGLE_DATASCI_NO_SERVE signals exchange server that a no-bid is due to data science
+	// prediction.
+	NO_BID_VUNGLE_DATASCI_NO_SERVE
+	// Add new entries here.
 
-// FIRST_NON_OPENRTB_NO_BID_REASON is a marker for the first element of the non-openrtb NoBidReason constants.
-const FIRST_NON_OPENRTB_NO_BID_REASON = NO_BID_RESPONSE_TIMEOUT
-
-// LAST_NON_OPENRTB_NO_BID_REASON is a marker for the last element of the non-openrtb NoBidReason constants.
-const LAST_NON_OPENRTB_NO_BID_REASON = lastNonOpenrtbNoBidReason
+	lastVungleNoBidReason
+)
 
 // NO_BID_REASON_NAMES gives a human-readable name of each NoBidReason.
 var NO_BID_REASON_NAMES = map[NoBidReason]string{
@@ -79,4 +110,7 @@ var NO_BID_REASON_NAMES = map[NoBidReason]string{
 	NO_BID_MALFORMATTED_PAYLOAD:     "NO_BID_MALFORMATTED_PAYLOAD",
 	NO_BID_BELOW_FLOOR:              "NO_BID_BELOW_FLOOR",
 	NO_BID_INVALID_CONTENT:          "NO_BID_INVALID_CONTENT",
+
+	NO_BID_VUNGLE_NO_CANDIDATES:    "NO_BID_VUNGLE_NO_CANDIDATES",
+	NO_BID_VUNGLE_DATASCI_NO_SERVE: "NO_BID_VUNGLE_DATASCI_NO_SERVE",
 }

--- a/openrtb/nobidreason_test.go
+++ b/openrtb/nobidreason_test.go
@@ -1,17 +1,18 @@
-package openrtb
+package openrtb_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Vungle/vungo/openrtb"
+)
 
 func TestNoBidReason(t *testing.T) {
-	for i := int(FIRST_OPENRTB_NO_BID_REASON); i < int(LAST_OPENRTB_NO_BID_REASON); i++ {
-		if _, ok := NO_BID_REASON_NAMES[NoBidReason(i)]; !ok {
-			t.Errorf("%d should exist in NO_BID_REASON_NAMES", i)
-		}
-	}
-
-	for i := int(FIRST_NON_OPENRTB_NO_BID_REASON); i < int(LAST_NON_OPENRTB_NO_BID_REASON); i++ {
-		if _, ok := NO_BID_REASON_NAMES[NoBidReason(i)]; !ok {
-			t.Errorf("%d should exist in NO_BID_REASON_NAMES", i)
+	for start, stop := range openrtb.NoBidReasonSections {
+		t.Logf("Verifying %s {%d...%d}:", openrtb.NO_BID_REASON_NAMES[start], start, stop)
+		for ; start < stop; start++ {
+			if _, ok := openrtb.NO_BID_REASON_NAMES[start]; !ok {
+				t.Errorf("%v must be an entry in NO_BID_REASON_NAMES", start)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# What

- Refactors `NoBidReason` sections and organization;
- Adds additional no-bid reasons for Vungle DSP;
- Adds documentation for each custom no-bid reasons.

# Acceptance

Vungle DSP can now reply with custom no-bid reasons to provide additional insights to an exchange auction