### PR TITLE
fix(openrtb): fix BidResponse validation for no-bid reason

### DIFF
--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -44,11 +44,7 @@ func (br *BidResponse) Validate(bidReq *BidRequest) error {
 	}
 
 	if len(br.SeatBids) == 0 {
-		if !br.isValidateNoBidReason() {
-			return ErrInvalidNoBidReasonValue
-		} else {
-			return nil
-		}
+		return br.NoBidReason.Validate()
 	}
 
 	if len(br.SeatBids) != 1 {
@@ -80,25 +76,6 @@ func (br *BidResponse) Validate(bidReq *BidRequest) error {
 	}
 
 	return nil
-}
-
-// isValidateNoBidReason method checks if the value of the no-bid-reason is a valid enum value.
-func (br *BidResponse) isValidateNoBidReason() bool {
-	switch br.NoBidReason {
-	case
-		NO_BID_UNKNOWN,
-		NO_BID_TECHNICAL_ERROR,
-		NO_BID_INVALID_REQUEST,
-		NO_BID_KNOWN_WEB_SPIDER,
-		NO_BID_NON_HUMAN_TRAFFIC,
-		NO_BID_PROXY_IP,
-		NO_BID_UNSUPPORTED_DEVICE,
-		NO_BID_BLOCKED_PUBLISHER,
-		NO_BID_UNMATCHED_USER:
-		return true
-	default:
-		return false
-	}
 }
 
 // GetOnlyBid methods returns the only bid object iff there is exactly one SeatBid object in which

--- a/openrtb/bidresponse_test.go
+++ b/openrtb/bidresponse_test.go
@@ -62,26 +62,23 @@ func TestBidResponseShouldReturnTheOnlyBid(t *testing.T) {
 }
 
 func TestBidResponseShouldValidateInvalidNoBidReasons(t *testing.T) {
-	// Given a BidResponse object whose no bid reason is not one of the enumerated values.
-	br := &openrtb.BidResponse{Id: "some-id", NoBidReason: openrtb.NoBidReason(1000)}
-
-	// When validating the bid response.
-	err := br.Validate(openrtbtest.NewBidRequestForTesting("some-id", ""))
-
-	// Expect the validation to return an error.
-	if err != openrtb.ErrInvalidNoBidReasonValue {
-		t.Error("Bid response should fail validation on invalid no bid reson.")
+	tests := []struct {
+		nbr     openrtb.NoBidReason
+		isValid bool
+	}{
+		{openrtb.NO_BID_BELOW_FLOOR, true},
+		{openrtb.NoBidReason(1010), false},
+		{openrtb.NO_BID_VUNGLE_DATASCI_NO_SERVE, true},
+		{openrtb.NO_BID_BELOW_FLOOR, true},
 	}
 
-	// After we update the value to a valid no bid reson.
-	br.NoBidReason = openrtb.NO_BID_INVALID_REQUEST
-
-	// When validating the bid response.
-	err = br.Validate(openrtbtest.NewBidRequestForTesting("some-id", ""))
-
-	// Expect the validation to pass.
-	if err != nil {
-		t.Error("Bid response validation should pass.")
+	for i, test := range tests {
+		t.Logf("Testing %d...", i)
+		resp := &openrtb.BidResponse{Id: "some-id", NoBidReason: test.nbr}
+		err := resp.Validate(openrtbtest.NewBidRequestForTesting("some-id", ""))
+		if (test.isValid && err != nil) || (!test.isValid && err != openrtb.ErrInvalidNoBidReasonValue) {
+			t.Errorf("Expected no-bid reason to be valid: %t, when the validation error is %v", test.isValid, err)
+		}
 	}
 }
 

--- a/openrtb/nobidreason.go
+++ b/openrtb/nobidreason.go
@@ -14,6 +14,16 @@ func (n NoBidReason) String() string {
 	return name
 }
 
+// Validate method validates the no-bid reason is one of the valid values, or returns an error
+// otherwise.
+func (n NoBidReason) Validate() error {
+	if _, ok := NO_BID_REASON_NAMES[n]; !ok {
+		return ErrInvalidNoBidReasonValue
+	}
+
+	return nil
+}
+
 // Standard no-bid reasons specified by OpenRTB 2.3.1.
 // See http://www.iab.net/media/file/OpenRTB_API_Specification_Version_2_3_1.pdf.
 //


### PR DESCRIPTION
# What

Bid response validation should accommodate validating against custom no-bid reasons.

# Acceptance

Custom no bid reasons should pass validation.