### PR TITLE
feat(openrtb): specify auction settlement price in MacroSubs

### DIFF
--- a/openrtb/macrosubs.go
+++ b/openrtb/macrosubs.go
@@ -25,20 +25,20 @@ const (
 )
 
 // createSubValues creates a map from the list of macro strings to their values in the given bidResponse.
-func createSubValues(bidRes *BidResponse) (subValues map[macro]string, err error) {
+func createSubValues(bidRes *BidResponse, s Settlement) (subValues map[macro]string, err error) {
 	bid, err := bidRes.GetOnlyBid()
 	if err != nil {
 		return nil, err
 	}
-	seatbid := bidRes.SeatBids[0]
+	seatBid := bidRes.SeatBids[0]
 
 	subValues = map[macro]string{
 		auctionID:       bidRes.Id,
 		auctionBidID:    bid.Id,
 		auctionImpID:    bid.ImpressionId,
-		auctionSeatID:   seatbid.Seat,
+		auctionSeatID:   seatBid.Seat,
 		auctionAdID:     bid.AdId,
-		auctionPrice:    strconv.FormatFloat(bid.Price, 'f', 2, 64),
+		auctionPrice:    strconv.FormatFloat(s.Price(), 'f', 2, 64),
 		auctionCurrency: string(bidRes.Currency),
 	}
 
@@ -96,8 +96,8 @@ var findMatchesPool = sync.Pool{
 // It takes a string which the substitutions should be performed on, and a *BidResponse to determine the values to be substituted.
 // MacroSubs assumes that the BidResponse has exactly one seat, which has exactly one bid.
 // If this is not true, it will return empty string and an error.
-func MacroSubs(stringToSub string, bidRes *BidResponse) (result string, err error) {
-	subValues, err := createSubValues(bidRes)
+func MacroSubs(stringToSub string, bidRes *BidResponse, s Settlement) (result string, err error) {
+	subValues, err := createSubValues(bidRes, s)
 	if err != nil {
 		return "", err
 	}
@@ -114,8 +114,8 @@ func MacroSubs(stringToSub string, bidRes *BidResponse) (result string, err erro
 // Use this when you are going to be doing many substitutions using the same BidResponse data.
 // CreateMacroSubstituter assumes that the BidResponse has exactly one seat, which has exactly one
 // bid. If this is not true, it will return nil and an error.
-func CreateMacroSubstituter(bidRes *BidResponse) (substituter *MacroSubstituter, err error) {
-	subValues, err := createSubValues(bidRes)
+func CreateMacroSubstituter(bidRes *BidResponse, s Settlement) (substituter *MacroSubstituter, err error) {
+	subValues, err := createSubValues(bidRes, s)
 	if err != nil {
 		return nil, err
 	}

--- a/openrtb/macrosubs_bench_test.go
+++ b/openrtb/macrosubs_bench_test.go
@@ -37,7 +37,7 @@ func benchmarkMacroSubs(subs int, b *testing.B) {
         ${AUCTION_IMP_ID}${AUCTION_SEAT_ID}${AUCTION_AD_ID}${AUCTION_AD_ID:B64}
         ${AUCTION_PRICE}${AUCTION_CURRENCY}abc${AUCTION_ID}${AUCTION_ID}def/n`, subs)
 
-	expectedOut, err := openrtb.MacroSubs(in, fakeBidResponse(), fakeAuctionResult())
+	expectedOut, err := openrtb.MacroSubs(in, fakeBidResponse(), testAuctionResult)
 	if err != nil {
 		b.Fatalf("Expected a succeful macro substitution for %v but got error %v instead.", in, err)
 	}
@@ -79,7 +79,7 @@ func benchmarkMacroSubs(subs int, b *testing.B) {
 // macroSubsWorker is a worker for performing openrtb.MacroSubs in BidResponses sent through its channel.
 func macroSubsWorker(sub string, in <-chan *openrtb.BidResponse, out chan<- string, wg *sync.WaitGroup, b *testing.B) {
 	for bidRes := range in {
-		if o, err := openrtb.MacroSubs(sub, bidRes, fakeAuctionResult()); err == nil {
+		if o, err := openrtb.MacroSubs(sub, bidRes, testAuctionResult); err == nil {
 			out <- o
 		} else {
 			b.Fatalf("Expected a succeful macro substitution for %v but got error %v instead.", in, err)
@@ -94,7 +94,7 @@ func fakeBidResponse() *openrtb.BidResponse {
 		AdId:         "Some ad id goes here",
 		Id:           "TheBidId!",
 		ImpressionId: "ImpressionIdForBid",
-		Price:        2.345,
+		Price:        testPrice,
 	}
 	var seatbid = openrtb.SeatBid{
 		Seat: "SeatBidIdentifier",
@@ -106,8 +106,4 @@ func fakeBidResponse() *openrtb.BidResponse {
 		Currency: openrtb.CURRENCY_USD,
 	}
 	return bidRes
-}
-
-func fakeAuctionResult() *auctionResult {
-	return &auctionResult{price: 2.345}
 }

--- a/openrtb/macrosubs_bench_test.go
+++ b/openrtb/macrosubs_bench_test.go
@@ -36,7 +36,8 @@ func benchmarkMacroSubs(subs int, b *testing.B) {
         abc${AUCTION_CURRENCY}def${AUCTION_ID}${AUCTION_BID_ID}
         ${AUCTION_IMP_ID}${AUCTION_SEAT_ID}${AUCTION_AD_ID}${AUCTION_AD_ID:B64}
         ${AUCTION_PRICE}${AUCTION_CURRENCY}abc${AUCTION_ID}${AUCTION_ID}def/n`, subs)
-	expectedOut, err := openrtb.MacroSubs(in, fakeBidResponse())
+
+	expectedOut, err := openrtb.MacroSubs(in, fakeBidResponse(), fakeAuctionResult())
 	if err != nil {
 		b.Fatalf("Expected a succeful macro substitution for %v but got error %v instead.", in, err)
 	}
@@ -78,7 +79,7 @@ func benchmarkMacroSubs(subs int, b *testing.B) {
 // macroSubsWorker is a worker for performing openrtb.MacroSubs in BidResponses sent through its channel.
 func macroSubsWorker(sub string, in <-chan *openrtb.BidResponse, out chan<- string, wg *sync.WaitGroup, b *testing.B) {
 	for bidRes := range in {
-		if o, err := openrtb.MacroSubs(sub, bidRes); err == nil {
+		if o, err := openrtb.MacroSubs(sub, bidRes, fakeAuctionResult()); err == nil {
 			out <- o
 		} else {
 			b.Fatalf("Expected a succeful macro substitution for %v but got error %v instead.", in, err)
@@ -105,4 +106,8 @@ func fakeBidResponse() *openrtb.BidResponse {
 		Currency: openrtb.CURRENCY_USD,
 	}
 	return bidRes
+}
+
+func fakeAuctionResult() *auctionResult {
+	return &auctionResult{price: 2.345}
 }

--- a/openrtb/macrosubs_test.go
+++ b/openrtb/macrosubs_test.go
@@ -6,106 +6,98 @@ import (
 	"github.com/Vungle/vungo/openrtb"
 )
 
-// verifyMacroSubs runs openrtb.MacroSubs and checks if the output is the expected string.
-func verifyMacroSubs(t *testing.T, input string, bidRes *openrtb.BidResponse, expectedOutput string) {
-	result, err := openrtb.MacroSubs(input, bidRes)
-	if err != nil {
-		t.Fatal("MacroSubs should complete successfully")
-	}
-
-	if result != expectedOutput {
-		t.Errorf("Got the wrong result.\nExpected: %s\nActual: %s", expectedOutput, result)
-	}
+type auctionResult struct {
+	price float64
 }
 
-// TestMacroSubs creates a number of tests cases and passes them to verifyMacroSubs.
+func (ar *auctionResult) Price() float64 {
+	return ar.price
+}
+
 func TestMacroSubs(t *testing.T) {
-	var bid = openrtb.Bid{
+	bid := openrtb.Bid{
 		AdId:         "Some ad id goes here",
 		Id:           "TheBidId!",
 		ImpressionId: "ImpressionIdForBid",
 		Price:        2.345,
 	}
-	var seatbid = openrtb.SeatBid{
+	seatBid := openrtb.SeatBid{
 		Seat: "SeatBidIdentifier",
 		Bids: []*openrtb.Bid{&bid},
 	}
-	var bidRes = &openrtb.BidResponse{
+	bidRes := &openrtb.BidResponse{
 		Id:       "1234",
-		SeatBids: []*openrtb.SeatBid{&seatbid},
+		SeatBids: []*openrtb.SeatBid{&seatBid},
 		Currency: openrtb.CURRENCY_USD,
 	}
-
-	var macroSubsTests = []struct {
-		input          string
-		bidRes         *openrtb.BidResponse
-		expectedOutput string
+	ar := &auctionResult{price: 2.345}
+	tests := []struct {
+		input    string
+		expected string
 	}{
-		{"abc${AUCTION_ID}def", bidRes, "abc1234def"},
-		{"abc${AUCTION_IDD}def", bidRes, "abc${AUCTION_IDD}def"},
-		{"abc${AUCTION_ID:B64}def", bidRes, "abcMTIzNA==def"},
-		{"abc${AUCTION_BID_ID}def", bidRes, "abcTheBidId!def"},
-		{"abc${AUCTION_IMP_ID}def", bidRes, "abcImpressionIdForBiddef"},
-		{"abc${AUCTION_SEAT_ID}def", bidRes, "abcSeatBidIdentifierdef"},
-		{"abc${AUCTION_AD_ID}def", bidRes, "abcSome ad id goes heredef"},
-		{"abc${AUCTION_PRICE}def", bidRes, "abc2.35def"},
-		{"abc${AUCTION_CURRENCY}def", bidRes, "abcUSDdef"},
+		{"abc${AUCTION_ID}def", "abc1234def"},
+		{"abc${AUCTION_IDD}def", "abc${AUCTION_IDD}def"},
+		{"abc${AUCTION_ID:B64}def", "abcMTIzNA==def"},
+		{"abc${AUCTION_BID_ID}def", "abcTheBidId!def"},
+		{"abc${AUCTION_IMP_ID}def", "abcImpressionIdForBiddef"},
+		{"abc${AUCTION_SEAT_ID}def", "abcSeatBidIdentifierdef"},
+		{"abc${AUCTION_AD_ID}def", "abcSome ad id goes heredef"},
+		{"abc${AUCTION_PRICE}def", "abc2.35def"},
+		{"abc${AUCTION_CURRENCY}def", "abcUSDdef"},
 		{
 			"${AUCTION_ID}${AUCTION_BID_ID}${AUCTION_IMP_ID}${AUCTION_SEAT_ID}" +
 				"${AUCTION_AD_ID}${AUCTION_AD_ID:B64}${AUCTION_PRICE}${AUCTION_CURRENCY}",
-			bidRes,
 			"1234TheBidId!ImpressionIdForBidSeatBidIdentifierSome ad id goes here" +
 				"U29tZSBhZCBpZCBnb2VzIGhlcmU=2.35USD",
 		},
-		{"abc${AUCTION_ID}${AUCTION_ID}def", bidRes, "abc12341234def"},
+		{"abc${AUCTION_ID}${AUCTION_ID}def", "abc12341234def"},
 	}
-
-	for i, tt := range macroSubsTests {
-		t.Logf("Testing %d", i)
-		verifyMacroSubs(t, tt.input, tt.bidRes, tt.expectedOutput)
+	for _, test := range tests {
+		actual, err := openrtb.MacroSubs(test.input, bidRes, ar)
+		if err != nil {
+			t.Errorf("MacroSubs err: %s", err)
+		}
+		if actual != test.expected {
+			t.Errorf("Expected \"%s\", but got: \"%s\"", test.expected, actual)
+		}
 	}
 }
 
 // TestMacroSubsErrCases checks cases where MacroSubs might have an error.
 // MacroSubs expects that the BidResponse has exactly one seat with exactly one bid.
 func TestMacroSubsErrCases(t *testing.T) {
-	var bid1 = openrtb.Bid{Id: "bid1"}
-	var bid2 = openrtb.Bid{Id: "bid2"}
-	var seatbidWith2Bids = openrtb.SeatBid{
+	bid1, bid2 := openrtb.Bid{Id: "bid1"}, openrtb.Bid{Id: "bid2"}
+	seatBidWith2Bids := openrtb.SeatBid{
 		Seat: "seatbidWith2Bids",
 		Bids: []*openrtb.Bid{&bid1, &bid2},
 	}
-	var bidResWith2Bids = &openrtb.BidResponse{
+	bidResWith2Bids := &openrtb.BidResponse{
 		Id:       "bidResWith2Bids",
-		SeatBids: []*openrtb.SeatBid{&seatbidWith2Bids},
+		SeatBids: []*openrtb.SeatBid{&seatBidWith2Bids},
 	}
-
-	var seatbid1 = openrtb.SeatBid{
+	seatBid1 := openrtb.SeatBid{
 		Seat: "seatbid1",
 		Bids: []*openrtb.Bid{&bid1},
 	}
-	var seatbid2 = openrtb.SeatBid{
+	seatBid2 := openrtb.SeatBid{
 		Seat: "seatbid2",
 		Bids: []*openrtb.Bid{&bid2},
 	}
-	var bidResWith2Seatbids = &openrtb.BidResponse{
+	bidResWith2SeatBids := &openrtb.BidResponse{
 		Id:       "bidResWith2Seatbids",
-		SeatBids: []*openrtb.SeatBid{&seatbid1, &seatbid2},
+		SeatBids: []*openrtb.SeatBid{&seatBid1, &seatBid2},
 	}
-
-	t.Log("Testing bidResWith2Bids")
-	result, err := openrtb.MacroSubs("${AUCTION_ID}${AUCTION_BID_ID}", bidResWith2Bids)
+	ar := &auctionResult{price: 2.345}
+	result, err := openrtb.MacroSubs("${AUCTION_ID}${AUCTION_BID_ID}", bidResWith2Bids, ar)
 	if err != openrtb.ErrIncorrectBidCount {
-		t.Error("bidResWith2Seatbids should give ErrIncorrectBidCount")
+		t.Error("bidResWith2Bids should give ErrIncorrectBidCount")
 	}
 	if result != "" {
 		t.Error("MacroSubs should empty string when there is an error")
 	}
-
-	t.Log("Testing bidResWith2Seatbids")
-	result, err = openrtb.MacroSubs("${AUCTION_ID}${AUCTION_SEAT_ID}", bidResWith2Seatbids)
+	result, err = openrtb.MacroSubs("${AUCTION_ID}${AUCTION_SEAT_ID}", bidResWith2SeatBids, ar)
 	if err != openrtb.ErrIncorrectSeatCount {
-		t.Error("bidResWith2Seatbids should give ErrIncorrectBidCount")
+		t.Error("bidResWith2SeatBids should give ErrIncorrectSeatCount")
 	}
 	if result != "" {
 		t.Error("MacroSubs should empty string when there is an error")

--- a/openrtb/settlement.go
+++ b/openrtb/settlement.go
@@ -1,0 +1,10 @@
+package openrtb
+
+// Settlement is the interface that provides auction settlement details.
+//
+// Exchanges should implement this interface on the relevant auction detail objects.
+//
+// Price returns the auction settlement price.
+type Settlement interface {
+	Price() float64
+}


### PR DESCRIPTION
Specify auction settlement price through an interface in MacroSubs in order to provide a price other than the bid price in the event that the auction settlement price is different from the bid price (e.g. in a second price auction).