### PR TITLE
fix(openrtb): Allow the minduration and maxduration fields be empty if there is no valid value.

### DIFF
--- a/openrtb/macrosubs_test.go
+++ b/openrtb/macrosubs_test.go
@@ -13,7 +13,7 @@ func (ar auctionResult) Price() float64 {
 }
 
 const (
-	testPrice = 2.345
+	testPrice         = 2.345
 	testAuctionResult = auctionResult(2.345)
 )
 

--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -4,8 +4,8 @@ package openrtb
 //easyjson:json
 type Video struct {
 	MimeTypes   []string `json:"mimes"`
-	MinDuration int      `json:"minduration"`
-	MaxDuration int      `json:"maxduration"`
+	MinDuration *int     `json:"minduration,omitempty"`
+	MaxDuration *int     `json:"maxduration,omitempty"`
 
 	// No Protocol(protocol). Use Protocols instead.
 


### PR DESCRIPTION
# What
Allow the minduration and maxduration fields be empty if there is no valid value.
# Acceptance
The minduration and maxduration fields can be empty if there is no valid value.