### PR TITLE
fix(openrtb): fix the way the tests count jsonfields

### DIFF
--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -106,8 +106,10 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 		tag := modelType.Field(i).Tag.Get("json")
 		if len(tag) > 0 && tag != "-" {
 			result++
+			continue
+		}
 
-		} else if modelType.Field(i).Type.Kind() == reflect.Struct {
+		if modelType.Field(i).Type.Kind() == reflect.Struct {
 			result += getNumOfJsonFields(modelType.Field(i).Type)
 		}
 	}

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -103,11 +103,12 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 	n := modelType.NumField()
 
 	for i := 0; i < n; i++ {
-		if modelType.Field(i).Type.Kind() == reflect.Struct {
-			result += getNumOfJsonFields(modelType.Field(i).Type)
-		}
-
 		tag := modelType.Field(i).Tag.Get("json")
+		if modelType.Field(i).Type.Kind() == reflect.Struct {
+			if len(tag) > 0 && tag != "-" {
+				result += getNumOfJsonFields(modelType.Field(i).Type)
+			}
+		}
 		if len(tag) > 0 && tag != "-" {
 			result++
 		}

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -109,6 +109,7 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 			continue
 		}
 
+		// decent into substructures
 		if modelType.Field(i).Type.Kind() == reflect.Struct {
 			result += getNumOfJsonFields(modelType.Field(i).Type)
 		}

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -106,10 +106,11 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 		tag := modelType.Field(i).Tag.Get("json")
 		if len(tag) > 0 && tag != "-" {
 			result++
-		} else {
-			if modelType.Field(i).Type.Kind() == reflect.Struct {
-				result += getNumOfJsonFields(modelType.Field(i).Type)
-			}
+			continue
+		}
+
+		if modelType.Field(i).Type.Kind() == reflect.Struct {
+			result += getNumOfJsonFields(modelType.Field(i).Type)
 		}
 	}
 

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -106,11 +106,8 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 		tag := modelType.Field(i).Tag.Get("json")
 		if len(tag) > 0 && tag != "-" {
 			result++
-			continue
-		}
 
-		// decent into substructures
-		if modelType.Field(i).Type.Kind() == reflect.Struct {
+		} else if modelType.Field(i).Type.Kind() == reflect.Struct {
 			result += getNumOfJsonFields(modelType.Field(i).Type)
 		}
 	}

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -103,6 +103,10 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 	n := modelType.NumField()
 
 	for i := 0; i < n; i++ {
+		if modelType.Field(i).Type.Kind() == reflect.Struct {
+			result += getNumOfJsonFields(modelType.Field(i).Type)
+		}
+
 		tag := modelType.Field(i).Tag.Get("json")
 		if len(tag) > 0 && tag != "-" {
 			result++

--- a/openrtb/openrtbtest/testutil.go
+++ b/openrtb/openrtbtest/testutil.go
@@ -104,13 +104,12 @@ func getNumOfJsonFields(modelType reflect.Type) (result int) {
 
 	for i := 0; i < n; i++ {
 		tag := modelType.Field(i).Tag.Get("json")
-		if modelType.Field(i).Type.Kind() == reflect.Struct {
-			if len(tag) > 0 && tag != "-" {
-				result += getNumOfJsonFields(modelType.Field(i).Type)
-			}
-		}
 		if len(tag) > 0 && tag != "-" {
 			result++
+		} else {
+			if modelType.Field(i).Type.Kind() == reflect.Struct {
+				result += getNumOfJsonFields(modelType.Field(i).Type)
+			}
 		}
 	}
 


### PR DESCRIPTION
# WHAT:
The current version of the test for the correct number of fields in a son object does not travers nested structures


# Acceptance
Count the number of arguments in a substructure for a full count of json fields