### PR TITLE
feat(bidrequest): include allimps field in bidrequest

### DIFF
--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -19,7 +19,7 @@ type BidRequest struct {
 	Timeout     int          `json:"tmax,omitempty"`
 
 	// No SeatWhitelist(wseat).
-	// No HasAllImpressions(allimps).
+	HasAllImpressions NumericBool `json:"allimps,omitempty"`
 
 	Currencies        []Currency `json:"cur,omitempty"`
 	BlockedCategories []Category `json:"bcat,omitempty"`

--- a/openrtb/testdata/bidrequest.json
+++ b/openrtb/testdata/bidrequest.json
@@ -111,6 +111,7 @@
   },
   "test": 1,
   "at": 1,
+  "allimps": 0,
   "tmax": 500,
   "cur": ["USD", "CNY"],
   "bcat": ["IAB7-39"],


### PR DESCRIPTION
# What 
----Open RTB V2----
Adds field allimps so we can start populating it