### PR TITLE
fix(openrtb): Settlement price should be precise to 9th decimal.

### DIFF
--- a/openrtb/macrosubs.go
+++ b/openrtb/macrosubs.go
@@ -38,7 +38,7 @@ func createSubValues(bidRes *BidResponse, s Settlement) (subValues map[macro]str
 		auctionImpID:    bid.ImpressionId,
 		auctionSeatID:   seatBid.Seat,
 		auctionAdID:     bid.AdId,
-		auctionPrice:    strconv.FormatFloat(s.Price(), 'f', 2, 64),
+		auctionPrice:    strconv.FormatFloat(s.Price(), 'f', 9, 64),
 		auctionCurrency: string(bidRes.Currency),
 	}
 

--- a/openrtb/macrosubs_test.go
+++ b/openrtb/macrosubs_test.go
@@ -44,13 +44,13 @@ func TestMacroSubs(t *testing.T) {
 		{"abc${AUCTION_IMP_ID}def", "abcImpressionIdForBiddef"},
 		{"abc${AUCTION_SEAT_ID}def", "abcSeatBidIdentifierdef"},
 		{"abc${AUCTION_AD_ID}def", "abcSome ad id goes heredef"},
-		{"abc${AUCTION_PRICE}def", "abc2.35def"},
+		{"abc${AUCTION_PRICE}def", "abc2.345000000def"},
 		{"abc${AUCTION_CURRENCY}def", "abcUSDdef"},
 		{
 			"${AUCTION_ID}${AUCTION_BID_ID}${AUCTION_IMP_ID}${AUCTION_SEAT_ID}" +
 				"${AUCTION_AD_ID}${AUCTION_AD_ID:B64}${AUCTION_PRICE}${AUCTION_CURRENCY}",
 			"1234TheBidId!ImpressionIdForBidSeatBidIdentifierSome ad id goes here" +
-				"U29tZSBhZCBpZCBnb2VzIGhlcmU=2.35USD",
+				"U29tZSBhZCBpZCBnb2VzIGhlcmU=2.345000000USD",
 		},
 		{"abc${AUCTION_ID}${AUCTION_ID}def", "abc12341234def"},
 	}
@@ -74,8 +74,8 @@ func TestMacroSubsDifferentSettlementPrice(t *testing.T) {
 	if err != nil {
 		t.Errorf("MacroSubsDifferentPrices: %s", err)
 	}
-	if actual != "price:11.11" {
-		t.Errorf(`Expected "price:11.11" but got: "%s"`, actual)
+	if actual != "price:11.110000000" {
+		t.Errorf(`Expected "price:11.110000000" but got: "%s"`, actual)
 	}
 }
 


### PR DESCRIPTION
# What 
This PR fix https://vungle.atlassian.net/browse/JAE-314.
# Acceptance
Settlement price should be precise to 9th decimal.
No impact to other services.