### PR TITLE
Implement extensions to allow for MOAT

### DIFF
--- a/vast/extension.go
+++ b/vast/extension.go
@@ -3,5 +3,16 @@ package vast
 // Extension type represents an <Extension> element that contains arbitrary XML data provided by the
 // platform to extend the VAST response.
 type Extension struct {
-	Data []byte `xml:",innerxml"`
+	Data          []byte          `xml:",innerxml"`
+	Verifications []*Verification `xml:"AdVerifications>Verification,omitempty"`
+}
+
+type Verification struct {
+	Vendor             string              `xml:"vendor,attr"`
+	ViewableImpression *ViewableImpression `xml:"ViewableImpression"`
+}
+
+type ViewableImpression struct {
+	ID   string      `xml:"id,attr"`
+	Data TrimmedData `xml:",cdata"`
 }

--- a/vast/extension.go
+++ b/vast/extension.go
@@ -3,13 +3,12 @@ package vast
 // Extension type represents an <Extension> element that contains arbitrary XML data provided by the
 // platform to extend the VAST response.
 type Extension struct {
-	Data          []byte          `xml:",innerxml"`
 	Verifications []*Verification `xml:"AdVerifications>Verification,omitempty"`
 }
 
 type Verification struct {
 	Vendor             string              `xml:"vendor,attr"`
-	ViewableImpression *ViewableImpression `xml:"ViewableImpression"`
+	ViewableImpression *ViewableImpression `xml:"ViewableImpression,omitempty"`
 }
 
 type ViewableImpression struct {

--- a/vast/testdata/extension.xml
+++ b/vast/testdata/extension.xml
@@ -12,4 +12,11 @@
       <Ugly>Whiskeys</Ugly>
     </Object>
   </Crazy>
+  <AdVerifications>
+    <Verification>
+      <ViewableImpression>
+        test data
+      </ViewableImpression>
+    </Verification>
+  </AdVerifications>
 </Extension>

--- a/vast/vastutil/unwrap.go
+++ b/vast/vastutil/unwrap.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 
+	internalvast "github.com/Vungle/jaeger/internal/vast"
 	"github.com/Vungle/vungo/vast"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
@@ -18,10 +19,10 @@ var defaultUnwrapClient = http.DefaultClient
 // 	1) Unwrapping context, ctx, is done;
 // 	2) Invalid XML format;
 // 	3) Invalid VAST content, (currently, there should be exactly one <Ad> within <VAST>.
-func Unwrap(ctx context.Context, data []byte) ([]*vast.Vast, error) {
+func Unwrap(ctx context.Context, data []byte) ([]*vast.Vast, internalvast.VastError) {
 	var v vast.Vast
 	if err := xml.Unmarshal(data, &v); err != nil {
-		return nil, err
+		return nil, internalvast.VastError{err, internalvast.XMLParsingError}
 	}
 
 	return unwrap(ctx, &v, nil)
@@ -30,7 +31,7 @@ func Unwrap(ctx context.Context, data []byte) ([]*vast.Vast, error) {
 // unwrap method is a helper function that invokes performs the actual HTTP request to get
 // additional VAST XML and updates the unwrappedList. The unwrap method is invoked recursively until
 // the first Inline VAST is reached or until an error occurs.
-func unwrap(ctx context.Context, v *vast.Vast, unwrappedList []*vast.Vast) ([]*vast.Vast, error) {
+func unwrap(ctx context.Context, v *vast.Vast, unwrappedList []*vast.Vast) ([]*vast.Vast, internalvast.VastError) {
 	if len(v.Ads) != 1 {
 		return nil, ErrUnwrapWithMultipleAds
 	} else if v.Ads[0].Wrapper == nil {
@@ -49,11 +50,12 @@ func unwrap(ctx context.Context, v *vast.Vast, unwrappedList []*vast.Vast) ([]*v
 			resp.Body.Close()
 		}
 	}()
-
 	if err != nil {
-		return nil, err
-	} else if err = xml.NewDecoder(resp.Body).Decode(&innerVast); err != nil {
-		return nil, err
+		return nil, internalvast.VastError{err, internalvast.WrapperTimeout}
+	}
+
+	if err = xml.NewDecoder(resp.Body).Decode(&innerVast); err != nil {
+		return nil, internalvast.VastError{err, internalvast.GeneralWrapperError}
 	} else {
 		// TODO(@garukun): Given a set of super fast VAST hosts and a starting wrapper VAST XML that
 		// wraps the VAST infinitely, this implementation could cause disastrous stack overflow that


### PR DESCRIPTION
# Context

This PR adds the extension for MOAT.

# Acceptance

This does not have negative impacts on production.

# Changes

* Added the extension AdVerifications>Verifications> ViewableImpression which MOAT uses for placing trackers.
