### PR TITLE
Adding a deep copy implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8.3
   - tip

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -47,5 +47,20 @@ func (bid Bid) Validate() error {
 // Copy returns a pointer to a copy of the bid object.
 func (b Bid) Copy() *Bid {
 	bCopy := b
+
+	// Copy over slices
+	if b.AdvertiserDomains != nil {
+		bCopy.AdvertiserDomains = make([]string, len(b.AdvertiserDomains))
+		copy(bCopy.AdvertiserDomains, b.AdvertiserDomains)
+	}
+	if b.Categories != nil {
+		bCopy.Categories = make([]Category, len(b.Categories))
+		copy(bCopy.Categories, b.Categories)
+	}
+	if b.CreativeAttributes != nil {
+		bCopy.CreativeAttributes = make([]CreativeAttribute, len(b.CreativeAttributes))
+		copy(bCopy.CreativeAttributes, b.CreativeAttributes)
+	}
+
 	return &bCopy
 }

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -61,6 +61,10 @@ func (b Bid) Copy() *Bid {
 		bCopy.CreativeAttributes = make([]CreativeAttribute, len(b.CreativeAttributes))
 		copy(bCopy.CreativeAttributes, b.CreativeAttributes)
 	}
+	if b.Extension != nil {
+		bCopy.Extension = make(json.RawMessage, len(b.Extension))
+		copy(bCopy.Extension, b.Extension)
+	}
 
 	return &bCopy
 }

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -44,7 +44,8 @@ func (bid Bid) Validate() error {
 	return nil
 }
 
-func (b *Bid) Copy() *Bid {
-	bCopy := *b
+// Copy returns a pointer to a copy of the bid object.
+func (b Bid) Copy() *Bid {
+	bCopy := b
 	return &bCopy
 }

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -43,3 +43,8 @@ func (bid Bid) Validate() error {
 
 	return nil
 }
+
+func (b *Bid) Copy() *Bid {
+	bCopy := *b
+	return &bCopy
+}

--- a/openrtb/bid.go
+++ b/openrtb/bid.go
@@ -53,14 +53,17 @@ func (b Bid) Copy() *Bid {
 		bCopy.AdvertiserDomains = make([]string, len(b.AdvertiserDomains))
 		copy(bCopy.AdvertiserDomains, b.AdvertiserDomains)
 	}
+
 	if b.Categories != nil {
 		bCopy.Categories = make([]Category, len(b.Categories))
 		copy(bCopy.Categories, b.Categories)
 	}
+
 	if b.CreativeAttributes != nil {
 		bCopy.CreativeAttributes = make([]CreativeAttribute, len(b.CreativeAttributes))
 		copy(bCopy.CreativeAttributes, b.CreativeAttributes)
 	}
+
 	if b.Extension != nil {
 		bCopy.Extension = make(json.RawMessage, len(b.Extension))
 		copy(bCopy.Extension, b.Extension)

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"bytes"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
 )
@@ -105,6 +107,7 @@ func TestBid_Copy(t *testing.T) {
 				DealID:             "testDealID",
 				Height:             0,
 				Width:              0,
+				Extension:          json.RawMessage([]byte(`rawr`)),
 			},
 		},
 	}
@@ -130,6 +133,13 @@ func TestBid_Copy(t *testing.T) {
 			b2.AdvertiserDomains[0] = "456"
 			if testCase.bid.AdvertiserDomains[0] == "456" {
 				t.Errorf("Bid b2 should not be pointing to original bid object attribute AdvertiserDomains.\ntestCase: %+v\nCopy: %+v", testCase.bid.AdvertiserDomains, b2.AdvertiserDomains)
+			}
+		}
+
+		if len(b2.Extension) > 0 {
+			b2.Extension = json.RawMessage([]byte(`rawr2`))
+			if bytes.Compare(testCase.bid.Extension, json.RawMessage([]byte(`rawr2`))) == 0 {
+				t.Errorf("Bid b2 should not be pointing to original bid object attribute Extension.\ntestCase: %+v\nCopy: %+v", testCase.bid.Extension, b2.Extension)
 			}
 		}
 	}

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
 )
@@ -55,6 +57,49 @@ func TestBidValidation(t *testing.T) {
 		err := testCase.bid.Validate()
 		if err != testCase.err {
 			t.Errorf("%v should return error (%s) instead of (%s).", testCase.bid, testCase.err, err)
+		}
+	}
+}
+
+func TestBid_Copy(t *testing.T) {
+	testCases := []struct {
+		bid *openrtb.Bid
+	}{
+		{
+			&openrtb.Bid{},
+		},
+		{
+			&openrtb.Bid{
+				ID:                 "test",
+				ImpressionID:       "testImpId",
+				Price:              0,
+				AdID:               "testAdID",
+				WinNotificationURL: "testWinNURL",
+				AdMarkup:           "testAdm",
+				AdvertiserDomains:  []string{},
+				Bundle:             "testBundle",
+				QualityImageURL:    "testQualityImgURL",
+				CampaignID:         "testCID",
+				CreativeID:         "testCrID",
+				Categories:         []openrtb.Category{},
+				CreativeAttributes: []openrtb.CreativeAttribute{},
+				DealID:             "testDealID",
+				Height:             0,
+				Width:              0,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		b2 := testCase.bid.Copy()
+
+		if b2 == testCase.bid {
+			t.Errorf("Address of bid should not be the same. b1: %v b2: %v.", &testCase.bid, &b2)
+		}
+
+		if !reflect.DeepEqual(testCase.bid, b2) {
+			b1JSON, _ := json.MarshalIndent(testCase.bid, "", "  ")
+			b2JSON, _ := json.MarshalIndent(b2, "", "  ")
+			t.Errorf("Bids should hold the same values.\nExpected: %s\n Got: %s", b1JSON, b2JSON)
 		}
 	}
 }

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -1,9 +1,9 @@
 package openrtb_test
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
+	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
@@ -87,6 +87,26 @@ func TestBid_Copy(t *testing.T) {
 				Width:              0,
 			},
 		},
+		{
+			&openrtb.Bid{
+				ID:                 "test",
+				ImpressionID:       "testImpId",
+				Price:              0,
+				AdID:               "testAdID",
+				WinNotificationURL: "testWinNURL",
+				AdMarkup:           "testAdm",
+				AdvertiserDomains:  []string{"123"},
+				Bundle:             "testBundle",
+				QualityImageURL:    "testQualityImgURL",
+				CampaignID:         "testCID",
+				CreativeID:         "testCrID",
+				Categories:         []openrtb.Category{openrtb.CategoryArtsEntertainment},
+				CreativeAttributes: []openrtb.CreativeAttribute{openrtb.CreativeAttributeAudioAuto},
+				DealID:             "testDealID",
+				Height:             0,
+				Width:              0,
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		b2 := testCase.bid.Copy()
@@ -99,6 +119,18 @@ func TestBid_Copy(t *testing.T) {
 			b1JSON, _ := json.MarshalIndent(testCase.bid, "", "  ")
 			b2JSON, _ := json.MarshalIndent(b2, "", "  ")
 			t.Errorf("Bids should hold the same values.\nExpected: %s\n Got: %s", b1JSON, b2JSON)
+		}
+
+		b2.ID = "1234"
+		if testCase.bid.ID == "1234" {
+			t.Errorf("bid b2 should not be pointing to original bid object.\n%+v\n%+v", testCase.bid, b2)
+		}
+
+		if len(b2.AdvertiserDomains) > 0 {
+			b2.AdvertiserDomains[0] = "456"
+			if testCase.bid.AdvertiserDomains[0] == "456" {
+				t.Errorf("bid b2 should not be pointing to original bid object attribute AdvertiserDomains.\n%+v\n%+v", testCase.bid.AdvertiserDomains, b2.AdvertiserDomains)
+			}
 		}
 	}
 }

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -1,9 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
@@ -123,13 +123,13 @@ func TestBid_Copy(t *testing.T) {
 
 		b2.ID = "1234"
 		if testCase.bid.ID == "1234" {
-			t.Errorf("bid b2 should not be pointing to original bid object.\n%+v\n%+v", testCase.bid, b2)
+			t.Errorf("Bid b2 should not be pointing to original bid object.\ntestCase: %+v\nCopy: %+v", testCase.bid, b2)
 		}
 
 		if len(b2.AdvertiserDomains) > 0 {
 			b2.AdvertiserDomains[0] = "456"
 			if testCase.bid.AdvertiserDomains[0] == "456" {
-				t.Errorf("bid b2 should not be pointing to original bid object attribute AdvertiserDomains.\n%+v\n%+v", testCase.bid.AdvertiserDomains, b2.AdvertiserDomains)
+				t.Errorf("Bid b2 should not be pointing to original bid object attribute AdvertiserDomains.\ntestCase: %+v\nCopy: %+v", testCase.bid.AdvertiserDomains, b2.AdvertiserDomains)
 			}
 		}
 	}

--- a/openrtb/bid_test.go
+++ b/openrtb/bid_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"bytes"
-
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
 )
@@ -115,7 +113,7 @@ func TestBid_Copy(t *testing.T) {
 		b2 := testCase.bid.Copy()
 
 		if b2 == testCase.bid {
-			t.Errorf("Address of bid should not be the same. b1: %v b2: %v.", &testCase.bid, &b2)
+			t.Errorf("Address of bid should not be the same. b1: %p b2: %p.", testCase.bid, b2)
 		}
 
 		if !reflect.DeepEqual(testCase.bid, b2) {
@@ -129,18 +127,17 @@ func TestBid_Copy(t *testing.T) {
 			t.Errorf("Bid b2 should not be pointing to original bid object.\ntestCase: %+v\nCopy: %+v", testCase.bid, b2)
 		}
 
-		if len(b2.AdvertiserDomains) > 0 {
-			b2.AdvertiserDomains[0] = "456"
-			if testCase.bid.AdvertiserDomains[0] == "456" {
-				t.Errorf("Bid b2 should not be pointing to original bid object attribute AdvertiserDomains.\ntestCase: %+v\nCopy: %+v", testCase.bid.AdvertiserDomains, b2.AdvertiserDomains)
+		for i := range testCase.bid.AdvertiserDomains {
+			if &testCase.bid.AdvertiserDomains[i] == &b2.AdvertiserDomains[i] {
+				t.Errorf("Address of AdvertiserDomains should not be the same in copied bid. seatbid1: %p seatbid2: %p.", testCase.bid.AdvertiserDomains[i], b2.AdvertiserDomains[i])
 			}
 		}
 
-		if len(b2.Extension) > 0 {
-			b2.Extension = json.RawMessage([]byte(`rawr2`))
-			if bytes.Compare(testCase.bid.Extension, json.RawMessage([]byte(`rawr2`))) == 0 {
-				t.Errorf("Bid b2 should not be pointing to original bid object attribute Extension.\ntestCase: %+v\nCopy: %+v", testCase.bid.Extension, b2.Extension)
+		for i := range testCase.bid.Extension {
+			if &testCase.bid.Extension[i] == &b2.Extension[i] {
+				t.Errorf("Address of Extension should not be the same in copied bid. seatbid1: %p seatbid2: %p.", testCase.bid.Extension[i], b2.Extension[i])
 			}
 		}
+
 	}
 }

--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -63,11 +63,10 @@ func (r BidResponse) String() string {
 }
 
 func (r *BidResponse) Copy() *BidResponse {
-	brCopy := &BidResponse{}
-	*brCopy = *r
+	brCopy := *r
 	brCopy.SeatBids = []*SeatBid{}
-	for _, sb := range r.SeatBids {
-		brCopy.SeatBids = append(brCopy.SeatBids, sb.Copy())
+	for _, seat := range r.SeatBids {
+		brCopy.SeatBids = append(brCopy.SeatBids, seat.Copy())
 	}
-	return brCopy
+	return &brCopy
 }

--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -65,9 +65,16 @@ func (r BidResponse) String() string {
 // Copy returns a pointer to a copy of the bidresponse object.
 func (r *BidResponse) Copy() *BidResponse {
 	brCopy := *r
+
 	brCopy.SeatBids = []*SeatBid{}
 	for _, seat := range r.SeatBids {
 		brCopy.SeatBids = append(brCopy.SeatBids, seat.Copy())
 	}
+
+	if r.Extension != nil {
+		brCopy.RawExtension = make(json.RawMessage, len(r.RawExtension))
+		copy(brCopy.RawExtension, r.RawExtension)
+	}
+
 	return &brCopy
 }

--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -61,3 +61,13 @@ func (r BidResponse) IsNoBid() bool {
 func (r BidResponse) String() string {
 	return fmt.Sprintf("[%s;%s;%v;%d]", r.ID, r.Currency, r.NoBidReason, len(r.SeatBids))
 }
+
+func (r *BidResponse) Copy() *BidResponse {
+	brCopy := &BidResponse{}
+	*brCopy = *r
+	brCopy.SeatBids = []*SeatBid{}
+	for _, sb := range r.SeatBids {
+		brCopy.SeatBids = append(brCopy.SeatBids, sb.Copy())
+	}
+	return brCopy
+}

--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -62,6 +62,7 @@ func (r BidResponse) String() string {
 	return fmt.Sprintf("[%s;%s;%v;%d]", r.ID, r.Currency, r.NoBidReason, len(r.SeatBids))
 }
 
+// Copy returns a pointer to a copy of the bidresponse object.
 func (r *BidResponse) Copy() *BidResponse {
 	brCopy := *r
 	brCopy.SeatBids = []*SeatBid{}

--- a/openrtb/bidresponse_test.go
+++ b/openrtb/bidresponse_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/bidresponse_test.go
+++ b/openrtb/bidresponse_test.go
@@ -1,11 +1,10 @@
 package openrtb_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"testing"
-
-	"bytes"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
@@ -131,12 +130,18 @@ func TestBidResponse_Copy(t *testing.T) {
 		b2 := testCase.bidresponse.Copy()
 
 		if b2 == testCase.bidresponse {
-			t.Errorf("Address of bidresponse should not be the same in copied bidrequest. bidresponse1: %v bidresponse2: %v", &testCase.bidresponse, &b2)
+			t.Errorf("Address of bidresponse should not be the same in copied bidrequest. bidresponse1: %p bidresponse2: %p", testCase.bidresponse, b2)
 		}
 
 		for i := range testCase.bidresponse.SeatBids {
 			if &testCase.bidresponse.SeatBids[i] == &b2.SeatBids[i] {
-				t.Errorf("Address of seatbids should not be the same in copied bidrequest. seatbid1: %v seatbid2: %v.", &testCase.bidresponse.SeatBids[i], &b2.SeatBids[i])
+				t.Errorf("Address of seatbids should not be the same in copied bidrequest. seatbid1: %p seatbid2: %p.", testCase.bidresponse.SeatBids[i], b2.SeatBids[i])
+			}
+		}
+
+		if testCase.bidresponse.RawExtension != nil {
+			if &testCase.bidresponse.RawExtension == &b2.RawExtension {
+				t.Errorf("Address of RawExtensions should not be the same in copied bidrequest. RawExtension1: %p RawExtension2: %p.", testCase.bidresponse.RawExtension, b2.RawExtension)
 			}
 		}
 

--- a/openrtb/bidresponse_test.go
+++ b/openrtb/bidresponse_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"bytes"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
 )
@@ -117,10 +119,11 @@ func TestBidResponse_Copy(t *testing.T) {
 				SeatBids: []*openrtb.SeatBid{
 					&openrtb.SeatBid{},
 				},
-				BidID:       "testBidID",
-				Currency:    openrtb.CurrencyUSD,
-				CustomData:  "testCustomData",
-				NoBidReason: openrtb.NoBidReasonUnknown,
+				BidID:        "testBidID",
+				Currency:     openrtb.CurrencyUSD,
+				CustomData:   "testCustomData",
+				NoBidReason:  openrtb.NoBidReasonUnknown,
+				RawExtension: json.RawMessage([]byte(`rawr`)),
 			},
 		},
 	}
@@ -137,9 +140,18 @@ func TestBidResponse_Copy(t *testing.T) {
 			}
 		}
 
+		if len(b2.RawExtension) > 0 {
+			b2.RawExtension = json.RawMessage([]byte(`rawr2`))
+			if bytes.Compare(testCase.bidresponse.RawExtension, json.RawMessage([]byte(`rawr2`))) == 0 {
+				t.Errorf("Bid b2 should not be pointing to original bid object attribute RawExtension.\ntestCase: %+v\nCopy: %+v", testCase.bidresponse.RawExtension, b2.RawExtension)
+			}
+		}
+
 		// Remove pointer slices so we can check other values with reflect.DeepEqual().
 		testCase.bidresponse.SeatBids = nil
 		b2.SeatBids = nil
+		testCase.bidresponse.RawExtension = nil
+		b2.RawExtension = nil
 
 		if !reflect.DeepEqual(testCase.bidresponse, b2) {
 			b1JSON, _ := json.MarshalIndent(testCase.bidresponse, "", "  ")

--- a/openrtb/seatbid.go
+++ b/openrtb/seatbid.go
@@ -20,3 +20,13 @@ func (b SeatBid) Validate() error {
 	}
 	return nil
 }
+
+func (sb *SeatBid) Copy() *SeatBid {
+	sbCopy := &SeatBid{}
+	*sbCopy = *sb
+	sbCopy.Bids = []*Bid{}
+	for _, b := range sb.Bids {
+		sbCopy.Bids = append(sbCopy.Bids, b.Copy())
+	}
+	return sbCopy
+}

--- a/openrtb/seatbid.go
+++ b/openrtb/seatbid.go
@@ -21,12 +21,11 @@ func (b SeatBid) Validate() error {
 	return nil
 }
 
-func (sb *SeatBid) Copy() *SeatBid {
-	sbCopy := &SeatBid{}
-	*sbCopy = *sb
-	sbCopy.Bids = []*Bid{}
-	for _, b := range sb.Bids {
-		sbCopy.Bids = append(sbCopy.Bids, b.Copy())
+func (b *SeatBid) Copy() *SeatBid {
+	bCopy := *b
+	bCopy.Bids = []*Bid{}
+	for _, bid := range b.Bids {
+		bCopy.Bids = append(bCopy.Bids, bid.Copy())
 	}
-	return sbCopy
+	return &bCopy
 }

--- a/openrtb/seatbid.go
+++ b/openrtb/seatbid.go
@@ -21,11 +21,13 @@ func (b SeatBid) Validate() error {
 	return nil
 }
 
+// Copy returns a pointer to a copy of the seatbid object.
 func (b *SeatBid) Copy() *SeatBid {
 	bCopy := *b
 	bCopy.Bids = []*Bid{}
 	for _, bid := range b.Bids {
-		bCopy.Bids = append(bCopy.Bids, bid.Copy())
+		bidCopy := bid.Copy()
+		bCopy.Bids = append(bCopy.Bids, bidCopy)
 	}
 	return &bCopy
 }

--- a/openrtb/seatbid_test.go
+++ b/openrtb/seatbid_test.go
@@ -1,11 +1,10 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/seatbid_test.go
+++ b/openrtb/seatbid_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
 )
@@ -66,5 +68,47 @@ func TestSeatBidValidation(t *testing.T) {
 				t.Errorf("%v should return error (%s) instead of (%s).", testCase.seatBid, testCase.err, err)
 			}
 		})
+	}
+}
+
+func TestSeatBid_Copy(t *testing.T) {
+	testCases := []struct {
+		seatbid *openrtb.SeatBid
+	}{
+		{
+			&openrtb.SeatBid{},
+		},
+		{
+			&openrtb.SeatBid{
+				Bids: []*openrtb.Bid{
+					&openrtb.Bid{ID: "1234"},
+				},
+				Seat:  "testSeat",
+				Group: 0,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		b2 := testCase.seatbid.Copy()
+
+		if b2 == testCase.seatbid {
+			t.Errorf("Address of seatbid should not be the same. seatbid1: %v seatbid2: %v", &testCase.seatbid, &b2)
+		}
+
+		for i := range testCase.seatbid.Bids {
+			if &testCase.seatbid.Bids[i] == &b2.Bids[i] {
+				t.Errorf("Address of bid should not be the same. bid1: %v bid2: %v.", &testCase.seatbid.Bids[i], &b2.Bids[i])
+			}
+		}
+
+		// Remove pointer slices so we can check other values with reflect.DeepEqual().
+		testCase.seatbid.Bids = nil
+		b2.Bids = nil
+
+		if !reflect.DeepEqual(testCase.seatbid, b2) {
+			b1JSON, _ := json.MarshalIndent(testCase.seatbid, "", "  ")
+			b2JSON, _ := json.MarshalIndent(b2, "", "  ")
+			t.Errorf("Seatbids should hold the same values.\nExpected: %s\n Got: %s", b1JSON, b2JSON)
+		}
 	}
 }


### PR DESCRIPTION
This is useful to have so that you can preserve the original bid response but also manipulate a copy for logging purposes such as when ad markup is too large.