### PR TITLE
feat(vercmp): add additional comparison functions

### DIFF
--- a/openrtb/vercmp/version.go
+++ b/openrtb/vercmp/version.go
@@ -16,10 +16,9 @@ func (v Version) cmp(other Version) int {
 	for nL, nR, idxL, idxR := 0, 0, 0, 0; idxL < len(v) || idxR < len(other); {
 		nL, idxL = scanInt(string(v), idxL)
 		nR, idxR = scanInt(string(other), idxR)
-		if nL == nR {
-			continue
+		if nL != nR {
+			return nL - nR
 		}
-		return nL - nR
 	}
 	return 0
 }

--- a/openrtb/vercmp/version.go
+++ b/openrtb/vercmp/version.go
@@ -12,6 +12,12 @@ import "strconv"
 // characters are considered as version 0.
 type Version string
 
+// cmp returns a value which indicates the Version's natural ordering relative to the given other Version. If the value
+// returned is negative, it indicates that the Version is less than the given other Version. If the value returned is
+// positive, it indicates that the Version is greater than the given other Version. If the value returned is equal to
+// zero, it indicates that the versions are equivalent. Versions are compared sequentially starting at the major
+// version with only digits in consideration. In other words, version 2 is greater than version 1 regardless of what
+// the minor version may be, and "alpha" is not comparable to "beta".
 func (v Version) cmp(other Version) int {
 	for nL, nR, idxL, idxR := 0, 0, 0, 0; idxL < len(v) || idxR < len(other); {
 		nL, idxL = scanInt(string(v), idxL)

--- a/openrtb/vercmp/version.go
+++ b/openrtb/vercmp/version.go
@@ -12,20 +12,41 @@ import "strconv"
 // characters are considered as version 0.
 type Version string
 
-// IsAbove method checks whether the Version is above the other given Version. Both versions are
-// compared sequentially starting at the major version. E.g. version 2 > version 1, regardless of
-// what the minor version may be.
-func (v Version) IsAbove(ver Version) bool {
-	for nL, nR, idxL, idxR := 0, 0, 0, 0; idxL < len(v) || idxR < len(ver); {
+func (v Version) cmp(other Version) int {
+	for nL, nR, idxL, idxR := 0, 0, 0, 0; idxL < len(v) || idxR < len(other); {
 		nL, idxL = scanInt(string(v), idxL)
-		nR, idxR = scanInt(string(ver), idxR)
-
-		if nL != nR {
-			return nL > nR
+		nR, idxR = scanInt(string(other), idxR)
+		if nL == nR {
+			continue
 		}
+		return nL - nR
 	}
+	return 0
+}
 
-	return false
+// IsAbove returns whether the Version is strictly above the given other Version.
+func (v Version) IsAbove(other Version) bool {
+	return v.cmp(other) > 0
+}
+
+// IsAboveOrEqual returns whether the Version is above or equal to the given other Version.
+func (v Version) IsAboveOrEqual(other Version) bool {
+	return v.cmp(other) >= 0
+}
+
+// IsBelow returns whether the Version is strictly below the given other Version.
+func (v Version) IsBelow(other Version) bool {
+	return v.cmp(other) < 0
+}
+
+// IsBelowOrEqual returns whether the Version is below or equal the given other Version.
+func (v Version) IsBelowOrEqual(other Version) bool {
+	return v.cmp(other) <= 0
+}
+
+// IsEqual returns whether the Version is strictly equal to the given other Version.
+func (v Version) IsEqual(other Version) bool {
+	return v.cmp(other) == 0
 }
 
 // scanInt method takes a string and a starting index within the string and scans for the next

--- a/openrtb/vercmp/version_test.go
+++ b/openrtb/vercmp/version_test.go
@@ -1,13 +1,16 @@
 package vercmp
 
 import (
+	"fmt"
 	"testing"
 )
 
-func TestVersionIsAbove(t *testing.T) {
+func TestVersion(t *testing.T) {
 	tests := []struct {
-		v1, v2           string
-		isAbove, isBelow bool
+		v1      string
+		v2      string
+		isAbove bool
+		isBelow bool
 	}{
 		// Testing behavior of valid inputs.
 		{"0.0.0", "0.0.0", false, false},
@@ -23,6 +26,17 @@ func TestVersionIsAbove(t *testing.T) {
 		{"9.10.7", "9.10.7", false, false},
 		{"9.10.7", "9.10.7rc", false, false},
 		{"8.2.15030.773", "8.2.15030.772", true, false},
+		{"8", "8", false, false},
+		{"8", "8.0", false, false},
+		{"8", "8.0.0", false, false},
+		{"8.0", "8", false, false},
+		{"8.0", "8.0", false, false},
+		{"8.0", "8.0.0", false, false},
+		{"8.0.0", "8", false, false},
+		{"8.0.0", "8.0", false, false},
+		{"8.0.0", "8.0.0", false, false},
+		{"8.0.0", "8.0.0rc", false, false},
+		{"8.0.0", "8.0.0-rc1", false, false},
 
 		// Testing behavior of invalid inputs.
 		{"", "9.10.7rc", false, true},
@@ -32,17 +46,52 @@ func TestVersionIsAbove(t *testing.T) {
 		{"a", "b", false, false},
 	}
 
-	for i, test := range tests {
-		t.Logf("Testing %d...", i)
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v and %v", test.v1, test.v2), func(t *testing.T) {
+			v1, v2 := Version(test.v1), Version(test.v2)
+			isEqual := !test.isAbove && !test.isBelow
+			isAboveOrEqual := test.isAbove || isEqual
+			isBelowOrEqual := test.isBelow || isEqual
 
-		v1, v2 := Version(test.v1), Version(test.v2)
+			if v1.IsAbove(v2) != test.isAbove {
+				t.Errorf("Expected %v to be above %v.", v1, v2)
+			}
 
-		if v1.IsAbove(v2) != test.isAbove {
-			t.Errorf("Expects version %s above %s to be %v.", v1, v2, test.isAbove)
-		}
+			if v2.IsBelow(v1) != test.isAbove {
+				t.Errorf("Expected %v to be below %v.", v2, v1)
+			}
 
-		if v2.IsAbove(v1) != test.isBelow {
-			t.Errorf("Expects version %s below %s to be %v.", v2, v1, test.isBelow)
-		}
+			if v1.IsAboveOrEqual(v2) != isAboveOrEqual {
+				t.Errorf("Expected %v to be above or equal to %v.", v1, v2)
+			}
+
+			if v2.IsBelowOrEqual(v1) != isAboveOrEqual {
+				t.Errorf("Expected %v to be below or equal to %v.", v2, v1)
+			}
+
+			if v1.IsBelow(v2) != test.isBelow {
+				t.Errorf("Expected %v to be below %v.", v1, v2)
+			}
+
+			if v2.IsAbove(v1) != test.isBelow {
+				t.Errorf("Expected %v to be above %v.", v2, v1)
+			}
+
+			if v1.IsBelowOrEqual(v2) != isBelowOrEqual {
+				t.Errorf("Expected %v to be below or equal to %v.", v1, v2)
+			}
+
+			if v2.IsAboveOrEqual(v1) != isBelowOrEqual {
+				t.Errorf("Expected %v to be above or equal to %v.", v2, v1)
+			}
+
+			if v1.IsEqual(v2) != isEqual {
+				t.Errorf("Expected %v to be equal to %v.", v1, v2)
+			}
+
+			if v2.IsEqual(v1) != isEqual {
+				t.Errorf("Expected %v to be equal to %v.", v2, v1)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# Context

This PR adds additional comparison functions for `Version`s in the `vercmp` package. The following new methods are added:
* `func (v Version) IsAboveOrEqual(other Version) bool`
* `func (v Version) IsBelow(other Version) bool`
* `func (v Version) IsBelowOrEqual(other Version) bool`
* `func (v Version) IsEqual(other Version) bool`