### PR TITLE
 fix(vast): wrapper creative check should be more lenient.

### DIFF
--- a/vast/creative.go
+++ b/vast/creative.go
@@ -24,33 +24,25 @@ func (creative *Creative) Validate() error {
 		if creative.CompanionAds != nil || creative.NonLinearAds != nil {
 			errors = append(errors, ErrCreativeType)
 		}
-	} else if creative.CompanionAds != nil {
-		if creative.NonLinearAds != nil {
-			errors = append(errors, ErrCreativeType)
-		}
-	} else if creative.NonLinearAds == nil {
-		errors = append(errors, ErrCreativeType)
-	}
-
-	if creative.Linear != nil {
 		if err := creative.Linear.Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {
 				errors = append(errors, ve.Errs...)
 			}
 		}
-	}
-
-	if creative.CompanionAds != nil {
+	} else if creative.CompanionAds != nil {
+		if creative.NonLinearAds != nil {
+			errors = append(errors, ErrCreativeType)
+		}
 		if err := creative.CompanionAds.Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {
 				errors = append(errors, ve.Errs...)
 			}
 		}
-	}
-
-	if creative.NonLinearAds != nil {
+	} else if creative.NonLinearAds == nil {
+		errors = append(errors, ErrCreativeType)
+	} else if creative.NonLinearAds != nil {
 		if err := creative.NonLinearAds.Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {

--- a/vast/creativewrapper.go
+++ b/vast/creativewrapper.go
@@ -16,7 +16,7 @@ type CreativeWrapper struct {
 // CreativeWrapper can contain up to one of LinearWrapper, CompanionAdsWrapper, and NonLinearAdsWrapper.
 func (cw *CreativeWrapper) Validate() error {
 	errors := make([]error, 0)
-	// Empty creative is valid for wrapper creative.
+	// Empty creative is valid for wrapper creative
 	if cw.Linear == nil && cw.CompanionAds == nil && cw.NonLinearAds == nil {
 		return nil
 	}

--- a/vast/creativewrapper.go
+++ b/vast/creativewrapper.go
@@ -13,7 +13,7 @@ type CreativeWrapper struct {
 }
 
 // Validate method validates the CreativeWrapper.
-// CreativeWrapper should contain exactly one of LinearWrapper, CompanionAdsWrapper, and NonLinearAdsWrapper.
+// CreativeWrapper can contain up to one of LinearWrapper, CompanionAdsWrapper, and NonLinearAdsWrapper.
 func (cw *CreativeWrapper) Validate() error {
 	errors := make([]error, 0)
 	// Empty creative is valid for wrapper creative.

--- a/vast/creativewrapper.go
+++ b/vast/creativewrapper.go
@@ -17,9 +17,9 @@ type CreativeWrapper struct {
 func (cw *CreativeWrapper) Validate() error {
 	errors := make([]error, 0)
 	// Empty creative is valid for wrapper creative.
-	//if cw.Linear == nil && cw.CompanionAds == nil && cw.NonLinearAds == nil {
-	//	return nil
-	//}
+	if cw.Linear == nil && cw.CompanionAds == nil && cw.NonLinearAds == nil {
+		return nil
+	}
 	if cw.Linear != nil {
 		if cw.CompanionAds != nil || cw.NonLinearAds != nil {
 			errors = append(errors, ErrCreativeWrapperType)

--- a/vast/creativewrapper.go
+++ b/vast/creativewrapper.go
@@ -16,6 +16,10 @@ type CreativeWrapper struct {
 // CreativeWrapper should contain exactly one of LinearWrapper, CompanionAdsWrapper, and NonLinearAdsWrapper.
 func (cw *CreativeWrapper) Validate() error {
 	errors := make([]error, 0)
+	// Empty creative is valid for wrapper creative.
+	//if cw.Linear == nil && cw.CompanionAds == nil && cw.NonLinearAds == nil {
+	//	return nil
+	//}
 	if cw.Linear != nil {
 		if cw.CompanionAds != nil || cw.NonLinearAds != nil {
 			errors = append(errors, ErrCreativeWrapperType)

--- a/vast/creativewrapper_test.go
+++ b/vast/creativewrapper_test.go
@@ -24,7 +24,7 @@ var creativeWrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.CreativeWrapper{}, vast.ErrCreativeWrapperType, "creativewrapper_without_companionads.xml"},
 	vasttest.VastTest{&vast.CreativeWrapper{}, vast.ErrIconResourcesFormat, "creativewrapper_error_linear.xml"},
 	vasttest.VastTest{&vast.CreativeWrapper{}, vast.ErrCompanionAdsWrapperMissCompanions, "creativewrapper_error_companionads.xml"},
-	vasttest.VastTest{&vast.CreativeWrapper{}, vast.ErrCreativeWrapperType, "creativewrapper_without_ads.xml"},
+	vasttest.VastTest{&vast.CreativeWrapper{}, nil, "creativewrapper_without_ads.xml"},
 }
 
 func TestCreativeWrapperValidateErrors(t *testing.T) {

--- a/vast/errors.go
+++ b/vast/errors.go
@@ -14,13 +14,13 @@ var ErrCompanionAdsMissCompanions = errors.New("CompanionAds miss Companions.")
 
 var ErrCompanionAdsWrapperMissCompanions = errors.New("CompanionAdsWrapper misses Companions.")
 
-var ErrCompanionResourceFormat = errors.New("Companion should only conatin one of IFrameResource, StaticResource, and HtmlResource.")
+var ErrCompanionResourceFormat = errors.New("Companion should only contain one of IFrameResource, StaticResource, and HtmlResource.")
 
 var ErrCompanionWrapperResourceFormat = errors.New("CompanionWrapperResource should only contain one of IFrameResource, StaticResource, and HtmlResource.")
 
-var ErrCreativeType = errors.New("Creative conatain should contain one type of NonLinearAds, Linear, CompanionAds.")
+var ErrCreativeType = errors.New("Creative should contain one type of NonLinearAds, Linear, CompanionAds.")
 
-var ErrCreativeWrapperType = errors.New("CreativeWrapper conatain should contain one type of NonLinearAds, Linear, CompanionAds.")
+var ErrCreativeWrapperType = errors.New("CreativeWrapper should contain one type of NonLinearAds, Linear, CompanionAds.")
 
 var ErrDurationEqualZero = errors.New("Duration is less than zero.")
 

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -15,7 +15,7 @@ func TestWrapperMarshalUnmarshal(t *testing.T) {
 }
 
 var wrapperTests = []vasttest.VastTest{
-	vasttest.VastTest{&vast.Wrapper{}, vast.ErrCreativeWrapperType, "wrapper.xml"},
+	vasttest.VastTest{&vast.Wrapper{}, vast.ErrIconResourcesFormat, "wrapper.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_valid.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrAdSystemMissSystem, "wrapper_error_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrImpressionMissUri, "wrapper_error_impression.xml"},


### PR DESCRIPTION
# Context

Creeatives under Wrapper tags are not required and should not fail when an empty creative is placed in Wrappers.

# Changes
* Add this condition to checking creatives in Wrappers `cw.Linear == nil && cw.CompanionAds == nil && cw.NonLinearAds == nil`
* Fixed typos