### PR TITLE
fix(vast): fix MediaFile tag validation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: go
 
 go:
   - 1.8.3
-  - tip

--- a/vast/mediafile.go
+++ b/vast/mediafile.go
@@ -1,6 +1,8 @@
 package vast
 
-import "github.com/Vungle/vungo/vast/defaults"
+import (
+	"github.com/Vungle/vungo/vast/defaults"
+)
 
 // MediaFile represents a <MediaFile> element that contains a reference to the creative asset in a
 // linear creative.
@@ -9,9 +11,9 @@ type MediaFile struct {
 	Delivery                  Delivery `xml:"delivery,attr"`             // Required.
 	MimeType                  string   `xml:"type,attr"`                 // Required.
 	Codec                     string   `xml:"codec,attr,omitempty"`      // VAST3.0.
-	Bitrate                   int      `xml:"bitrate,attr,omitempty"`    // In Kbps; absent if MaxBitrate and MinBitrate are present.
-	MinBitrate                int      `xml:"minBitrate,attr,omitempty"` // In Kbps; absent if Bitrate is present. VAST3.0.
-	MaxBitrate                int      `xml:"maxBitrate,attr,omitempty"` // In Kbps; absent if Bitrate is present. VAST3.0.
+	Bitrate                   *int     `xml:"bitrate,attr,omitempty"`    // In Kbps; absent if MaxBitrate and MinBitrate are present.
+	MinBitrate                *int     `xml:"minBitrate,attr,omitempty"` // In Kbps; absent if Bitrate is present. VAST3.0.
+	MaxBitrate                *int     `xml:"maxBitrate,attr,omitempty"` // In Kbps; absent if Bitrate is present. VAST3.0.
 	Width                     int      `xml:"width,attr"`                // Required.
 	Height                    int      `xml:"height,attr"`               // Required.
 	IsScalable                bool     `xml:"scalable,attr,omitempty"`
@@ -49,22 +51,19 @@ func (mediaFile *MediaFile) Validate() error {
 		errors = append(errors, ErrMediaFileMissUri)
 	}
 
-	if mediaFile.Bitrate != 0 {
-		if mediaFile.Bitrate < defaults.MIN_VIDEO_BITRATE {
+	if mediaFile.Bitrate != nil {
+		if *mediaFile.Bitrate < defaults.MIN_VIDEO_BITRATE {
 			errors = append(errors, ErrMediaFileBitrateTooLow)
 		}
-
-		if mediaFile.Bitrate > defaults.MAX_VIDEO_BITRATE {
+		if *mediaFile.Bitrate > defaults.MAX_VIDEO_BITRATE {
 			errors = append(errors, ErrMediaFileBitrateTooHigh)
 		}
-	} else {
-		if mediaFile.MaxBitrate < defaults.MIN_VIDEO_BITRATE {
-			errors = append(errors, ErrMediaFileBitrateTooLow)
-		}
-
-		if mediaFile.MinBitrate > defaults.MAX_VIDEO_BITRATE {
-			errors = append(errors, ErrMediaFileBitrateTooHigh)
-		}
+	}
+	if mediaFile.MaxBitrate != nil && *mediaFile.MaxBitrate < defaults.MIN_VIDEO_BITRATE {
+		errors = append(errors, ErrMediaFileBitrateTooLow)
+	}
+	if mediaFile.MinBitrate != nil && *mediaFile.MinBitrate > defaults.MAX_VIDEO_BITRATE {
+		errors = append(errors, ErrMediaFileBitrateTooHigh)
 	}
 
 	if mediaFile.Width > defaults.MAX_VIDEO_WIDTH {

--- a/vast/mediafile_test.go
+++ b/vast/mediafile_test.go
@@ -24,6 +24,7 @@ var mediaFileTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileMissUri, "mediafile_without_uri.xml"},
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileBitrateTooHigh, "mediafile_bitrate_too_high.xml"},
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileBitrateTooLow, "mediafile_bitrate_too_low.xml"},
+	vasttest.VastTest{&vast.MediaFile{}, nil, "mediafile_without_bitrate.xml"},
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileHeightTooHigh, "mediafile_height_too_high.xml"},
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileHeightTooLow, "mediafile_height_too_low.xml"},
 	vasttest.VastTest{&vast.MediaFile{}, vast.ErrMediaFileWidthTooHigh, "mediafile_width_too_high.xml"},

--- a/vast/testdata/mediafile_without_bitrate.xml
+++ b/vast/testdata/mediafile_without_bitrate.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MediaFile
+    id="some-id"
+    delivery="progressive"
+    type="video/mp4"
+    codec="H-264"
+    width="8"
+    height="16"
+    scalable="true"
+    maintainAspectRatio="true"
+    apiFramework="Vungle Exchange"><![CDATA[http://link/to/the/video]]></MediaFile>


### PR DESCRIPTION
# Context

Mediafile bitrate check was not accurate since unmarshalling integers always returns 0 as the default. Change this to a pointer to capture existence of the attribute.

# Changes
* Changed `Bitrate`, `MinBitrate`, `MaxBitrate` fields to take pointers of integers.
* Fixed checks for these fields.