### PR TITLE
refactor(*): deprecate use of x/net/context and x/net/context/ctxhttp in favor of context

### DIFF
--- a/openrtb/openrtbutil/client.go
+++ b/openrtb/openrtbutil/client.go
@@ -2,6 +2,7 @@ package openrtbutil
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Vungle/vungo/openrtb"
-	"golang.org/x/net/context"
 )
 
 // defaultDiscardDuration is the default amount of time the client will spend on trying to discard

--- a/openrtb/openrtbutil/client_functional_test.go
+++ b/openrtb/openrtbutil/client_functional_test.go
@@ -1,6 +1,7 @@
 package openrtbutil_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbutil"
-	"golang.org/x/net/context"
 )
 
 // setupTestServer method starts up a test server and returns a dummy bid response. Caller may

--- a/openrtb/openrtbutil/client_test.go
+++ b/openrtb/openrtbutil/client_test.go
@@ -2,6 +2,7 @@ package openrtbutil
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/Vungle/vungo/openrtb"
-	"golang.org/x/net/context"
 )
 
 // MakeSimpleRequest sends a dummy bid request to the specified url just to get some bid response

--- a/openrtb/openrtbutil/example_test.go
+++ b/openrtb/openrtbutil/example_test.go
@@ -1,12 +1,12 @@
 package openrtbutil_test
 
 import (
+	"context"
 	"fmt"
 	"net"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbutil"
-	"golang.org/x/net/context"
 )
 
 func ExampleClient() {

--- a/openrtb/openrtbutil/openrtbutil.go
+++ b/openrtb/openrtbutil/openrtbutil.go
@@ -1,9 +1,10 @@
 package openrtbutil
 
 import (
-	"github.com/Vungle/vungo/openrtb"
-	"golang.org/x/net/context"
+	"context"
 	"net/http"
+
+	"github.com/Vungle/vungo/openrtb"
 )
 
 // RequestBid method sends a high-level bid request to a given endpoint for a bid response over the

--- a/openrtb/openrtbutil/request.go
+++ b/openrtb/openrtbutil/request.go
@@ -2,10 +2,10 @@ package openrtbutil
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 
 	"github.com/Vungle/vungo/openrtb"
-	"golang.org/x/net/context"
 )
 
 // Request represents a high-level bid request object constructed with an existing bid request, HTTP

--- a/openrtb/openrtbutil/request_test.go
+++ b/openrtb/openrtbutil/request_test.go
@@ -1,6 +1,7 @@
 package openrtbutil_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"reflect"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbutil"
-	"golang.org/x/net/context"
 )
 
 func TestNewRequestError(t *testing.T) {

--- a/vast/vastutil/unwrap.go
+++ b/vast/vastutil/unwrap.go
@@ -1,12 +1,11 @@
 package vastutil
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 
 	"github.com/Vungle/vungo/vast"
-	"golang.org/x/net/context"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 var defaultUnwrapClient = http.DefaultClient
@@ -43,7 +42,16 @@ func unwrap(ctx context.Context, v *vast.Vast, unwrappedList []*vast.Vast) ([]*v
 	}
 
 	var innerVast vast.Vast
-	resp, err := ctxhttp.Get(ctx, defaultUnwrapClient, w.VastAdTagUri)
+
+	req, err := http.NewRequest("GET", w.VastAdTagUri, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	resp, err := defaultUnwrapClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if resp != nil && resp.Body != nil {
 			resp.Body.Close()

--- a/vast/vastutil/unwrap_test.go
+++ b/vast/vastutil/unwrap_test.go
@@ -1,17 +1,18 @@
 package vastutil_test
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Vungle/vungo/vast"
 	"github.com/Vungle/vungo/vast/vastutil"
-	"golang.org/x/net/context"
 )
 
 func TestUnwrap(t *testing.T) {
@@ -82,8 +83,8 @@ func TestUnwrapShouldRespectContext(t *testing.T) {
 	_, err = vastutil.Unwrap(ctx, data)
 
 	// Expect error to occur.
-	if err != context.Canceled {
-		t.Errorf("Error should have been %v instead of %v.", context.Canceled, err)
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Errorf("Expected %v, got %v.", context.Canceled, err)
 	}
 }
 


### PR DESCRIPTION
# Context

This PR deprecates the use of `golang.org/x/net/context` and `golang.org/x/net/context/ctxhttp` in favor of `context`, which was added in go1.7. This change breaks backwards-compatibility with go<1.7.