### PR TITLE
fix(vast): There should not be a check for adparameters.

### DIFF
--- a/vast/adparameters.go
+++ b/vast/adparameters.go
@@ -6,13 +6,3 @@ type AdParameters struct {
 
 	IsXmlEncoded bool `xml:"xmlEncoded,attr,omitempty"` // VAST3.0.
 }
-
-// Validate method validates the AdParameters according to the VAST.
-// Parameters are required.
-func (p *AdParameters) Validate() error {
-	if len(p.Parameters) == 0 {
-		return ValidationError{Errs: []error{ErrAdParametersMissParameters}}
-	}
-
-	return nil
-}

--- a/vast/adparameters_test.go
+++ b/vast/adparameters_test.go
@@ -15,12 +15,6 @@ func TestAdParametersMarshalUnmarshal(t *testing.T) {
 	vasttest.VerifyModelAgainstFile(t, "AdParameters", "adparameters.xml", AdParametersModelType)
 }
 
-func TestAdParametersValidateError(t *testing.T) {
-	vasttest.VerifyVastElementFromFile(t, "testdata/adparameters.xml", &vast.AdParameters{}, nil)
-	vasttest.VerifyVastElementFromBytes(t, []byte(`<AdParameters xmlEncoded="true"></AdParameters>`),
-		&vast.AdParameters{}, vast.ErrAdParametersMissParameters)
-}
-
 func TestAdParametersWithWhitespace(t *testing.T) {
 	xmlData := `<AdParameters>
 	<![CDATA[just me]]>

--- a/vast/companion.go
+++ b/vast/companion.go
@@ -59,15 +59,6 @@ func (companion *Companion) Validate() error {
 		}
 	}
 
-	if companion.AdParameters != nil {
-		if err := companion.AdParameters.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	}
-
 	if len(errors) > 0 {
 		return ValidationError{Errs: errors}
 	}

--- a/vast/companion_test.go
+++ b/vast/companion_test.go
@@ -19,7 +19,7 @@ var companionTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Companion{}, nil, "companion_with_staticresource.xml"},
 	vasttest.VastTest{&vast.Companion{}, nil, "companion_with_iframeresource.xml"},
 	vasttest.VastTest{&vast.Companion{}, nil, "companion_with_htmlresource.xml"},
-	vasttest.VastTest{&vast.Companion{}, vast.ErrAdParametersMissParameters, "companion_error_adparameters.xml"},
+	vasttest.VastTest{&vast.Companion{}, nil, "companion_error_adparameters.xml"},
 	vasttest.VastTest{&vast.Companion{}, vast.ErrHtmlResourceMissHtml, "companion_error_htmlresource.xml"},
 	vasttest.VastTest{&vast.Companion{}, vast.ErrCompanionResourceFormat, "companion_without_resource.xml"},
 	vasttest.VastTest{&vast.Companion{}, vast.ErrCompanionResourceFormat, "companion_without_staticresource.xml"},

--- a/vast/companionwrapper.go
+++ b/vast/companionwrapper.go
@@ -27,14 +27,6 @@ type CompanionWrapper struct {
 // Validate method validates the CompanionWrapper according to the VAST.
 func (c *CompanionWrapper) Validate() error {
 	errors := make([]error, 0)
-	if c.AdParameters != nil {
-		if err := c.AdParameters.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	}
 
 	for _, tracking := range c.Trackings {
 		if err := tracking.Validate(); err != nil {

--- a/vast/companionwrapper_test.go
+++ b/vast/companionwrapper_test.go
@@ -23,7 +23,7 @@ var companionWrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.CompanionWrapper{}, vast.ErrCompanionWrapperResourceFormat, "companionwrapper_without_staticresource.xml"},
 	vasttest.VastTest{&vast.CompanionWrapper{}, vast.ErrCompanionWrapperResourceFormat, "companionwrapper_without_iframeresource.xml"},
 	vasttest.VastTest{&vast.CompanionWrapper{}, vast.ErrCompanionWrapperResourceFormat, "companionwrapper_without_htmlresource.xml"},
-	vasttest.VastTest{&vast.CompanionWrapper{}, vast.ErrAdParametersMissParameters, "companionwrapper_error_adparameters.xml"},
+	vasttest.VastTest{&vast.CompanionWrapper{}, nil, "companionwrapper_error_adparameters.xml"},
 	vasttest.VastTest{&vast.CompanionWrapper{}, vast.ErrHtmlResourceMissHtml, "companionwrapper_error_htmlresource.xml"},
 }
 

--- a/vast/errors.go
+++ b/vast/errors.go
@@ -4,8 +4,6 @@ import "errors"
 
 // Please keep the variables alphabetized.
 
-var ErrAdParametersMissParameters = errors.New("AdParameters misses Parameters.")
-
 var ErrAdSystemMissSystem = errors.New("AdSystem misses system.")
 
 var ErrAdType = errors.New("Ad should only contain one of Inline and Wrapper.")

--- a/vast/linear.go
+++ b/vast/linear.go
@@ -56,15 +56,6 @@ func (linear *Linear) Validate() error {
 		}
 	}
 
-	if linear.AdParameters != nil {
-		if err := linear.AdParameters.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	}
-
 	var err error
 	var validMedia *MediaFile
 	for _, mediaFile := range linear.MediaFiles {

--- a/vast/linear_test.go
+++ b/vast/linear_test.go
@@ -21,7 +21,7 @@ var linearTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Linear{}, nil, "linear_valid.xml"},
 	vasttest.VastTest{&vast.Linear{}, nil, "linear_at_least_one_valid_mediafile.xml"},
 	vasttest.VastTest{&vast.Linear{}, vast.ErrLinearMissMediaFiles, "linear_without_mediafiles.xml"},
-	vasttest.VastTest{&vast.Linear{}, vast.ErrAdParametersMissParameters, "linear_error_adparameters.xml"},
+	vasttest.VastTest{&vast.Linear{}, nil, "linear_error_adparameters.xml"},
 	vasttest.VastTest{&vast.Linear{}, vast.ErrDurationEqualZero, "linear_error_duration.xml"},
 	vasttest.VastTest{&vast.Linear{}, vast.ErrIconResourcesFormat, "linear_error_icon.xml"},
 	vasttest.VastTest{&vast.Linear{}, vast.ErrMediaFileSize, "linear_error_mediafiles.xml"},

--- a/vast/vastutil/validationresult.go
+++ b/vast/vastutil/validationresult.go
@@ -30,7 +30,6 @@ const (
 	RESULT_UNWRAP_WITH_MULTIPLE_ADS   VastValidationResult = 10000
 	RESULT_WRAPPER_MISSING_AD_TAG_URI VastValidationResult = 10001
 
-	RESULT_AD_PARAMETERS_MISS_PARAMETERS         VastValidationResult = 20000
 	RESULT_AD_SYSTEM_MISS_SYSTEM                 VastValidationResult = 20001
 	RESULT_AD_TYPE                               VastValidationResult = 20002
 	RESULT_COMPANION_ADS_MISS_COMPANIONS         VastValidationResult = 20003
@@ -100,8 +99,6 @@ func getValidationResultFromErr(err error) VastValidationResult {
 	case ErrWrapperMissingAdTagUri:
 		return RESULT_WRAPPER_MISSING_AD_TAG_URI
 
-	case vast.ErrAdParametersMissParameters:
-		return RESULT_AD_PARAMETERS_MISS_PARAMETERS
 	case vast.ErrAdSystemMissSystem:
 		return RESULT_AD_SYSTEM_MISS_SYSTEM
 	case vast.ErrAdType:


### PR DESCRIPTION
The VAST 2.0 specification does not require the adparameters field even if the tag exists.