### PR TITLE
fix(vast): remove impression requirement for wrappers.

### DIFF
--- a/vast/ad_test.go
+++ b/vast/ad_test.go
@@ -18,7 +18,7 @@ var adTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Ad{}, vast.ErrAdType, "ad.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_wrapper.xml"},
-	vasttest.VastTest{&vast.Ad{}, vast.ErrInlineMissImpressions, "ad_error_inline.xml"},
+	vasttest.VastTest{&vast.Ad{}, nil, "ad_error_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, vast.ErrCompanionWrapperResourceFormat, "ad_error_wrapper.xml"},
 }
 

--- a/vast/ad_test.go
+++ b/vast/ad_test.go
@@ -19,7 +19,7 @@ var adTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_wrapper.xml"},
 	vasttest.VastTest{&vast.Ad{}, vast.ErrInlineMissImpressions, "ad_error_inline.xml"},
-	vasttest.VastTest{&vast.Ad{}, vast.ErrWrapperMissImpressions, "ad_error_wrapper.xml"},
+	vasttest.VastTest{&vast.Ad{}, vast.ErrCompanionWrapperResourceFormat, "ad_error_wrapper.xml"},
 }
 
 func TestAdValidateErrors(t *testing.T) {

--- a/vast/inline.go
+++ b/vast/inline.go
@@ -31,10 +31,6 @@ func (inline *InLine) Validate() error {
 		errors = append(errors, ErrInlineMissAdTitle)
 	}
 
-	if len(inline.Impressions) == 0 {
-		errors = append(errors, ErrInlineMissImpressions)
-	}
-
 	if len(inline.Creatives) == 0 {
 		errors = append(errors, ErrInlineMissCreatives)
 	}

--- a/vast/inline_test.go
+++ b/vast/inline_test.go
@@ -18,7 +18,7 @@ var inlineTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.InLine{}, nil, "inline_valid.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissAdTitle, "inline_without_adtitle.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissCreatives, "inline_without_creatives.xml"},
-	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissImpressions, "inline_without_impressions.xml"},
+	vasttest.VastTest{&vast.InLine{}, nil, "inline_without_impressions.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrAdSystemMissSystem, "inline_without_adsystem.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrCreativeType, "inline_error_creatives.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrImpressionMissUri, "inline_error_impressions.xml"},

--- a/vast/wrapper.go
+++ b/vast/wrapper.go
@@ -29,10 +29,6 @@ func (w *Wrapper) Validate() error {
 		errors = append(errors, ErrWrapperMissVastAdTagUri)
 	}
 
-	if len(w.Impressions) == 0 {
-		errors = append(errors, ErrWrapperMissImpressions)
-	}
-
 	for _, impression := range w.Impressions {
 		if err := impression.Validate(); err != nil {
 			ve, ok := err.(ValidationError)

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -20,7 +20,7 @@ var wrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrAdSystemMissSystem, "wrapper_error_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrImpressionMissUri, "wrapper_error_impression.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissVastAdTagUri, "wrapper_without_adtaguri.xml"},
-	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissImpressions, "wrapper_without_impression.xml"},
+	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_without_impression.xml"},
 }
 
 func TestWrapperValidateErrors(t *testing.T) {


### PR DESCRIPTION
# Context

Wrappers don't require an impression tag if the unwrapped tag contains an impression.

We will need a follow up to actually validate this properly.

# Acceptance

This should result in more impressions from wrapped VAST tags.

# Changes

* Remove impression check for wrappers.
