### PR TITLE
 feat(openrtb): add the ability to create a deep copy of bid requests.

### DIFF
--- a/openrtb/application.go
+++ b/openrtb/application.go
@@ -28,3 +28,28 @@ type Application struct {
 func (a Application) Validate() error {
 	return nil
 }
+
+func (a *Application) Copy() *Application {
+	appCopy := *a
+
+	if appCopy.Categories != nil {
+		appCopy.Categories = make([]Category, len(a.Categories))
+		copy(appCopy.Categories, a.Categories)
+	}
+
+	if appCopy.SectionCategories != nil {
+		appCopy.SectionCategories = make([]Category, len(a.SectionCategories))
+		copy(appCopy.SectionCategories, a.SectionCategories)
+	}
+
+	if appCopy.PageCategories != nil {
+		appCopy.PageCategories = make([]Category, len(a.PageCategories))
+		copy(appCopy.PageCategories, a.PageCategories)
+	}
+
+	if a.Publisher != nil {
+		appCopy.Publisher = a.Publisher.Copy()
+	}
+
+	return &appCopy
+}

--- a/openrtb/application_test.go
+++ b/openrtb/application_test.go
@@ -4,12 +4,84 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var ApplicationModelType = reflect.TypeOf(openrtb.Application{})
 
 func TestApplicationMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "application.json", ApplicationModelType)
+}
+
+func TestApplication_Copy(t *testing.T) {
+	testCases := []struct {
+		application *openrtb.Application
+	}{
+		{
+			&openrtb.Application{},
+		},
+		{
+			&openrtb.Application{
+				ID:                "testID",
+				Name:              "testName",
+				Bundle:            "testBundle",
+				Domain:            "testDomain",
+				StoreURL:          "testStoreURL",
+				Categories:        []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+				SectionCategories: []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+				PageCategories:    []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+				Version:           "testVersion",
+				HasPrivacyPolicy:  true,
+				IsPaid:            true,
+				Publisher: &openrtb.Publisher{
+					ID:         "testPublisher",
+					Name:       "testName",
+					Categories: []openrtb.Category{},
+					Domain:     "testDomain",
+				},
+				Keywords:  "testKeywords",
+				Extension: "testExtension",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		application2 := testCase.application.Copy()
+
+		if application2 == testCase.application {
+			t.Errorf("Address of application should not be the same in copied application. application1: %p application2: %p", testCase.application, application2)
+		}
+
+		if &testCase.application.Categories == &application2.Categories {
+			t.Errorf("Address of blocked advertisers should not be the same in copied application. Categories1: %p Categories2: %p.", testCase.application.Categories, application2.Categories)
+		}
+
+		if &testCase.application.SectionCategories == &application2.SectionCategories {
+			t.Errorf("Address of blocked advertisers should not be the same in copied application. SectionCategories1: %p SectionCategories2: %p.", testCase.application.SectionCategories, application2.SectionCategories)
+		}
+
+		if &testCase.application.PageCategories == &application2.PageCategories {
+			t.Errorf("Address of blocked advertisers should not be the same in copied application. PageCategories1: %p PageCategories2: %p.", testCase.application.PageCategories, application2.PageCategories)
+		}
+
+		if testCase.application.Publisher != nil {
+			if &testCase.application.Publisher == &application2.Publisher {
+				t.Errorf("Address of Publisher should not be the same in copied application. Publisher1: %p Publisher2: %p.", testCase.application.Publisher, application2.Publisher)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.application, application2) {
+			application1JSON, _ := json.MarshalIndent(testCase.application, "", "  ")
+			application2JSON, _ := json.MarshalIndent(application2, "", "  ")
+			t.Errorf("Videos should hold the same values.\nExpected: %s\n Got: %s", application1JSON, application2JSON)
+		}
+
+		if diff := deep.Equal(testCase.application, application2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/application_test.go
+++ b/openrtb/application_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
@@ -40,7 +39,7 @@ func TestApplication_Copy(t *testing.T) {
 				Publisher: &openrtb.Publisher{
 					ID:         "testPublisher",
 					Name:       "testName",
-					Categories: []openrtb.Category{},
+					Categories: []openrtb.Category{openrtb.CategoryAdvertising},
 					Domain:     "testDomain",
 				},
 				Keywords:  "testKeywords",

--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -44,3 +44,53 @@ func (r BidRequest) Validate() error {
 func (r BidRequest) String() string {
 	return fmt.Sprintf("[%s;%d]", r.ID, len(r.Impressions))
 }
+
+// Copy returns a pointer to a copy of the BidRequest object.
+func (r *BidRequest) Copy() *BidRequest {
+	brCopy := *r
+
+	if r.Impressions != nil {
+		brCopy.Impressions = []*Impression{}
+		for i := range r.Impressions {
+			brCopy.Impressions = append(brCopy.Impressions, r.Impressions[i].Copy())
+		}
+	}
+
+	if r.Application != nil {
+		brCopy.Application = r.Application.Copy()
+	}
+
+	if r.Device != nil {
+		brCopy.Device = r.Device.Copy()
+	}
+
+	if r.User != nil {
+		brCopy.User = r.User.Copy()
+	}
+
+	if r.WhitelistedSeats != nil {
+		brCopy.WhitelistedSeats = make([]string, len(r.WhitelistedSeats))
+		copy(brCopy.WhitelistedSeats, r.WhitelistedSeats)
+	}
+
+	if r.Currencies != nil {
+		brCopy.Currencies = make([]Currency, len(r.Currencies))
+		copy(brCopy.Currencies, r.Currencies)
+	}
+
+	if r.BlockedCategories != nil {
+		brCopy.BlockedCategories = make([]Category, len(r.BlockedCategories))
+		copy(brCopy.BlockedCategories, r.BlockedCategories)
+	}
+
+	if r.BlockedAdvertisers != nil {
+		brCopy.BlockedAdvertisers = make([]string, len(r.BlockedAdvertisers))
+		copy(brCopy.BlockedAdvertisers, r.BlockedAdvertisers)
+	}
+
+	if r.Regulation != nil {
+		brCopy.Regulation = r.Regulation.Copy()
+	}
+
+	return &brCopy
+}

--- a/openrtb/bidrequest_test.go
+++ b/openrtb/bidrequest_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/bidrequest_test.go
+++ b/openrtb/bidrequest_test.go
@@ -4,8 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var BidRequestModelType = reflect.TypeOf(openrtb.BidRequest{})
@@ -28,5 +31,206 @@ func TestBidRequestValidateShouldValidateAgainstId(t *testing.T) {
 
 	if err := bidRequest.Validate(); err == nil || err != openrtb.ErrInvalidBidRequestID {
 		t.Errorf("BidRequest.ID (%s) must be non-empty to be valid.", bidRequest.ID)
+	}
+}
+
+func TestBidRequest_Copy(t *testing.T) {
+	testInt := 1
+	testBool := openrtb.NumericBool(true)
+
+	testCases := []struct {
+		bidrequest *openrtb.BidRequest
+	}{
+		{
+			&openrtb.BidRequest{},
+		},
+		{
+			&openrtb.BidRequest{
+				Impressions: []*openrtb.Impression{
+					&openrtb.Impression{
+						ID: "testImpression",
+						Video: &openrtb.Video{
+							MIMETypes:       []string{"mp4"},
+							MinDuration:     &testInt,
+							MaxDuration:     &testInt,
+							Protocols:       []openrtb.VideoProtocol{openrtb.VideoProtocolVAST2},
+							Width:           1,
+							Height:          1,
+							StartDelay:      &testInt,
+							Linearity:       1,
+							MinBitRate:      1,
+							MaxBitRate:      1,
+							IsBoxingAllowed: true,
+							PlaybackMethods: []openrtb.PlaybackMethod{openrtb.PlaybackMethodAutoPlaySoundOn},
+							DeliveryMethods: []openrtb.DeliveryMethod{openrtb.DeliveryMethodStreaming},
+							Position:        1,
+							APIFrameworks:   []openrtb.APIFramework{openrtb.APIFrameworkVPAID1},
+						},
+						BidFloorPrice:    1.0,
+						BidFloorCurrency: openrtb.CurrencyUSD,
+						PrivateMarketplace: &openrtb.PrivateMarketplace{
+							IsPrivateAuction: true,
+							Deals: []*openrtb.Deal{
+								&openrtb.Deal{
+									ID:               "testDeal",
+									BidFloorPrice:    1.0,
+									BidFloorCurrency: openrtb.CurrencyUSD,
+									AuctionType:      openrtb.AuctionTypeSecondPrice,
+									WhitelistedSeats: []string{"testWLSeat"},
+								},
+							},
+						},
+					},
+				},
+				Application: &openrtb.Application{
+					ID:                "testApplication",
+					Name:              "test",
+					Bundle:            "testBundle",
+					Domain:            "testDomain",
+					StoreURL:          "testStoreURL",
+					Categories:        []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+					SectionCategories: []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+					PageCategories:    []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+					Version:           "1",
+					HasPrivacyPolicy:  true,
+					IsPaid:            true,
+					Publisher: &openrtb.Publisher{
+						ID:         "testPublisher",
+						Name:       "test",
+						Categories: []openrtb.Category{openrtb.CategoryArtsAndEntertainment},
+						Domain:     "testDomain",
+					},
+					Keywords: "testKeyword",
+				},
+				Device: &openrtb.Device{
+					BrowserUserAgent:     "",
+					Geo:                  &openrtb.Geo{},
+					HasDoNotTrack:        &testBool,
+					HasLimitedAdTracking: &testBool,
+					IP:                   "",
+					IPv6:                 "",
+					Type:                 openrtb.DeviceTypePhone,
+					Make:                 "testMake",
+					Model:                "testModel",
+					OS:                   "testOS",
+					OSVersion:            "testOSVersion",
+					HardwareVersion:      "testHardwareVersion",
+					Height:               1,
+					Width:                1,
+					PPI:                  1,
+					PixelRatio:           1.0,
+					SupportsJavaScript:   &testBool,
+					FlashVersion:         "testFlashVersion",
+					Language:             "testLanguage",
+					Carrier:              "testCarrier",
+					ConnectionType:       openrtb.ConnectionTypeWiFi,
+					IFA:                  "testIFA",
+					HardwareIDSHA1:       "testHardwareIDSHA1",
+					HardwareIDMD5:        "testHardwareIDMD5",
+					PlatformIDSHA1:       "testPlatformIDSHA1",
+					PlatformIDMD5:        "testPlatformIDMD5",
+					MACSHA1:              "testMACSHA1",
+					MACMD5:               "testMACMD5",
+				},
+				User: &openrtb.User{
+					ID:         "testUser",
+					BuyerID:    "testBuyerID",
+					BirthYear:  1,
+					Gender:     openrtb.GenderMale,
+					Keywords:   "testKeyword",
+					CustomData: "testCustomData",
+					Geo: &openrtb.Geo{
+						Latitude:  1.0,
+						Longitude: 1.0,
+						Type:      openrtb.GeoTypeIP,
+						Country:   "testCountry",
+						Region:    "testRegion",
+						Metro:     "testMetro",
+						City:      "testCity",
+						ZipCode:   "testZipCode",
+						UTCOffset: 1,
+					},
+				},
+				AuctionType:        1,
+				Timeout:            1,
+				WhitelistedSeats:   []string{"1"},
+				Currencies:         []openrtb.Currency{openrtb.CurrencyUSD},
+				BlockedCategories:  []openrtb.Category{openrtb.Category712Education},
+				BlockedAdvertisers: []string{"advertiser1"},
+				Regulation: &openrtb.Regulation{
+					IsCoppaCompliant: &testBool,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		b2 := testCase.bidrequest.Copy()
+
+		if b2 == testCase.bidrequest {
+			t.Errorf("Address of bidrequest should not be the same in copied bidrequest. bidrequest1: %p bidrequest2: %p", testCase.bidrequest, b2)
+		}
+
+		for i := range testCase.bidrequest.Impressions {
+			if &testCase.bidrequest.Impressions[i] == &b2.Impressions[i] {
+				t.Errorf("Address of impressions should not be the same in copied bidrequest. Impressions1: %p Impressions2: %p.", testCase.bidrequest.Impressions[i], b2.Impressions[i])
+			}
+		}
+
+		if testCase.bidrequest.Application != nil {
+			if &testCase.bidrequest.Application == &b2.Application {
+				t.Errorf("Address of Application should not be the same in copied bidrequest. Application1: %p Application2: %p.", testCase.bidrequest.Application, b2.Application)
+			}
+		}
+
+		if testCase.bidrequest.Device != nil {
+			if &testCase.bidrequest.Device == &b2.Device {
+				t.Errorf("Address of Device should not be the same in copied bidrequest. Device1: %p Device2: %p.", testCase.bidrequest.Device, b2.Device)
+			}
+		}
+
+		if testCase.bidrequest.User != nil {
+			if &testCase.bidrequest.User == &b2.User {
+				t.Errorf("Address of User should not be the same in copied bidrequest. User1: %p User2: %p.", testCase.bidrequest.User, b2.User)
+			}
+		}
+
+		if testCase.bidrequest.Regulation != nil {
+			if &testCase.bidrequest.Regulation == &b2.Regulation {
+				t.Errorf("Address of Regulation should not be the same in copied bidrequest. Regulation1: %p Regulation2: %p.", testCase.bidrequest.Regulation, b2.Regulation)
+			}
+		}
+
+		if &testCase.bidrequest.WhitelistedSeats == &b2.WhitelistedSeats {
+			t.Errorf("Address of whitelisted seats should not be the same in copied bidrequest. WhitelistedSeats1: %p WhitelistedSeats2: %p.", testCase.bidrequest.WhitelistedSeats, b2.WhitelistedSeats)
+		}
+
+		if &testCase.bidrequest.Currencies == &b2.Currencies {
+			t.Errorf("Address of currencies should not be the same in copied bidrequest. Currencies1: %p Currencies2: %p.", testCase.bidrequest.Currencies, b2.Currencies)
+		}
+
+		if &testCase.bidrequest.BlockedCategories == &b2.BlockedCategories {
+			t.Errorf("Address of blocked categories should not be the same in copied bidrequest. BlockedCategories1: %p BlockedCategories2: %p.", testCase.bidrequest.BlockedCategories, b2.BlockedCategories)
+		}
+
+		if &testCase.bidrequest.BlockedAdvertisers == &b2.BlockedAdvertisers {
+			t.Errorf("Address of blocked advertisers should not be the same in copied bidrequest. BlockedAdvertisers1: %p BlockedAdvertisers2: %p.", testCase.bidrequest.BlockedAdvertisers, b2.BlockedAdvertisers)
+		}
+
+		if testCase.bidrequest.Regulation != nil {
+			if &testCase.bidrequest.Regulation == &b2.Regulation {
+				t.Errorf("Address of Regulation should not be the same in copied bidrequest. Regulation1: %p Regulation2: %p.", testCase.bidrequest.Regulation, b2.Regulation)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.bidrequest, b2) {
+			b1JSON, _ := json.MarshalIndent(testCase.bidrequest, "", "  ")
+			b2JSON, _ := json.MarshalIndent(b2, "", "  ")
+			t.Errorf("Bid requests should hold the same values.\nExpected: %s\n Got: %s", b1JSON, b2JSON)
+		}
+
+		if diff := deep.Equal(testCase.bidrequest, b2); diff != nil {
+			t.Error(diff)
+		}
 	}
 }

--- a/openrtb/deal.go
+++ b/openrtb/deal.go
@@ -12,3 +12,14 @@ type Deal struct {
 	AuctionType      AuctionType `json:"at,omitempty"`
 	WhitelistedSeats []string    `json:"wseat,omitempty"`
 }
+
+func (d *Deal) Copy() *Deal {
+	dealCopy := *d
+
+	if d.WhitelistedSeats != nil {
+		dealCopy.WhitelistedSeats = make([]string, len(d.WhitelistedSeats))
+		copy(dealCopy.WhitelistedSeats, d.WhitelistedSeats)
+	}
+
+	return &dealCopy
+}

--- a/openrtb/deal_test.go
+++ b/openrtb/deal_test.go
@@ -1,0 +1,47 @@
+package openrtb_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/Vungle/vungo/openrtb"
+	"github.com/go-test/deep"
+)
+
+func TestDeal_Copy(t *testing.T) {
+	testCases := []struct {
+		deal *openrtb.Deal
+	}{
+		{
+			&openrtb.Deal{},
+		},
+		{
+			&openrtb.Deal{
+				ID:               "",
+				BidFloorPrice:    1.0,
+				BidFloorCurrency: "USD",
+				AuctionType:      openrtb.AuctionTypeSecondPrice,
+				WhitelistedSeats: []string{"1"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		deal2 := testCase.deal.Copy()
+
+		if &testCase.deal.WhitelistedSeats == &deal2.WhitelistedSeats {
+			t.Errorf("Address of WhitelistedSeats should not be the same in copied deal. WhitelistedSeats1: %p WhitelistedSeats2: %p.", testCase.deal.WhitelistedSeats, deal2.WhitelistedSeats)
+		}
+
+		if !reflect.DeepEqual(testCase.deal, deal2) {
+			deal1JSON, _ := json.MarshalIndent(testCase.deal, "", "  ")
+			deal2JSON, _ := json.MarshalIndent(deal2, "", "  ")
+			t.Errorf("Deals should hold the same values.\nExpected: %s\n Got: %s", deal1JSON, deal2JSON)
+		}
+
+		if diff := deep.Equal(testCase.deal, deal2); diff != nil {
+			t.Error(diff)
+		}
+	}
+}

--- a/openrtb/device.go
+++ b/openrtb/device.go
@@ -36,3 +36,29 @@ type Device struct {
 	MACMD5               string         `json:"macmd5,omitempty"`
 	Extension            interface{}    `json:"ext,omitempty"`
 }
+
+func (d *Device) Copy() *Device {
+	deviceCopy := *d
+
+	if d.Geo != nil {
+		geoCopy := *d.Geo
+		deviceCopy.Geo = &geoCopy
+	}
+
+	if d.HasDoNotTrack != nil {
+		HasDoNotTrackCopy := *d.HasDoNotTrack
+		deviceCopy.HasDoNotTrack = &HasDoNotTrackCopy
+	}
+
+	if d.HasLimitedAdTracking != nil {
+		HasLimitedAdTrackingCopy := *d.HasLimitedAdTracking
+		deviceCopy.HasLimitedAdTracking = &HasLimitedAdTrackingCopy
+	}
+
+	if d.SupportsJavaScript != nil {
+		SupportsJavaScriptCopy := *d.SupportsJavaScript
+		deviceCopy.SupportsJavaScript = &SupportsJavaScriptCopy
+	}
+
+	return &deviceCopy
+}

--- a/openrtb/device_test.go
+++ b/openrtb/device_test.go
@@ -4,12 +4,106 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var DeviceModelType = reflect.TypeOf(openrtb.Device{})
 
 func TestDeviceMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "device.json", DeviceModelType)
+}
+
+func TestDevice_Copy(t *testing.T) {
+	testBool := openrtb.NumericBool(true)
+	testCases := []struct {
+		device *openrtb.Device
+	}{
+		{
+			&openrtb.Device{},
+		},
+		{
+			&openrtb.Device{
+				BrowserUserAgent: "testBrowserUserAgent",
+				Geo: &openrtb.Geo{
+					Latitude:  1,
+					Longitude: 1,
+					Type:      openrtb.GeoTypeGPS,
+					Country:   "testCountry",
+					Region:    "testRegion",
+					Metro:     "testMetro",
+					City:      "testCity",
+					ZipCode:   "123",
+					UTCOffset: 1,
+				},
+				HasDoNotTrack:        &testBool,
+				HasLimitedAdTracking: &testBool,
+				IP:                   "testIP",
+				IPv6:                 "testIPv6",
+				Type:                 openrtb.DeviceTypeMobileTablet,
+				Make:                 "testMake",
+				Model:                "testModel",
+				OS:                   openrtb.OSIOS,
+				OSVersion:            "1",
+				HardwareVersion:      "1",
+				Height:               1,
+				Width:                1,
+				PPI:                  1,
+				PixelRatio:           1,
+				SupportsJavaScript:   &testBool,
+				FlashVersion:         "1",
+				Language:             "1",
+				Carrier:              "1",
+				ConnectionType:       openrtb.ConnectionTypeWiFi,
+				IFA:                  "1",
+				HardwareIDSHA1:       "testHardwareIDSHA1",
+				HardwareIDMD5:        "testHardwareIDMD5",
+				PlatformIDSHA1:       "testPlatformIDSHA1",
+				PlatformIDMD5:        "testPlatformIDMD5",
+				MACSHA1:              "testMACSHA1",
+				MACMD5:               "testMACMD5",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		device2 := testCase.device.Copy()
+
+		if testCase.device.Geo != nil {
+			if &testCase.device.Geo == &device2.Geo {
+				t.Errorf("Address of Geo should not be the same in copied device. Geo1: %p Geo2: %p.", testCase.device.Geo, device2.Geo)
+			}
+		}
+
+		if testCase.device.HasDoNotTrack != nil {
+			if &testCase.device.HasDoNotTrack == &device2.HasDoNotTrack {
+				t.Errorf("Address of HasDoNotTrack should not be the same in copied device. HasDoNotTrack1: %p HasDoNotTrack2: %p.", testCase.device.HasDoNotTrack, device2.HasDoNotTrack)
+			}
+		}
+
+		if testCase.device.HasLimitedAdTracking != nil {
+			if &testCase.device.HasLimitedAdTracking == &device2.HasLimitedAdTracking {
+				t.Errorf("Address of HasLimitedAdTracking should not be the same in copied device. HasLimitedAdTracking1: %p HasLimitedAdTracking2: %p.", testCase.device.HasLimitedAdTracking, device2.HasLimitedAdTracking)
+			}
+		}
+
+		if testCase.device.SupportsJavaScript != nil {
+			if &testCase.device.SupportsJavaScript == &device2.SupportsJavaScript {
+				t.Errorf("Address of SupportsJavaScript should not be the same in copied device. SupportsJavaScript1: %p SupportsJavaScript2: %p.", testCase.device.SupportsJavaScript, device2.SupportsJavaScript)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.device, device2) {
+			device1JSON, _ := json.MarshalIndent(testCase.device, "", "  ")
+			device2JSON, _ := json.MarshalIndent(device2, "", "  ")
+			t.Errorf("Devices should hold the same values.\nExpected: %s\n Got: %s", device1JSON, device2JSON)
+		}
+
+		if diff := deep.Equal(testCase.device, device2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/device_test.go
+++ b/openrtb/device_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/impression.go
+++ b/openrtb/impression.go
@@ -19,3 +19,20 @@ type Impression struct {
 	PrivateMarketplace    *PrivateMarketplace `json:"pmp,omitempty"`
 	Extension             interface{}         `json:"ext,omitempty"`
 }
+
+// Copy returns a pointer to a copy of the Impression object.
+func (imp *Impression) Copy() *Impression {
+	impressionCopy := *imp
+	if imp.Video != nil {
+		impressionCopy.Video = imp.Video.Copy()
+	}
+
+	if imp.PrivateMarketplace != nil {
+		impressionCopy.PrivateMarketplace = imp.PrivateMarketplace.Copy()
+	}
+
+	// extension copying has to be done by the user of this package manually.
+	impressionCopy.Extension = nil
+
+	return &impressionCopy
+}

--- a/openrtb/impression_test.go
+++ b/openrtb/impression_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/impression_test.go
+++ b/openrtb/impression_test.go
@@ -4,12 +4,80 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var ImpressionModelType = reflect.TypeOf(openrtb.Impression{})
 
 func TestImpressionMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "impression.json", ImpressionModelType)
+}
+
+func TestImpression_Copy(t *testing.T) {
+	testInt := 1
+	testCases := []struct {
+		impression *openrtb.Impression
+	}{
+		{
+			&openrtb.Impression{},
+		},
+		{
+			&openrtb.Impression{
+				ID: "1",
+				Video: &openrtb.Video{
+					MIMETypes:       []string{"testMime"},
+					MinDuration:     &testInt,
+					MaxDuration:     &testInt,
+					Protocols:       []openrtb.VideoProtocol{openrtb.VideoProtocolVAST2},
+					Width:           1,
+					Height:          1,
+					StartDelay:      &testInt,
+					Linearity:       openrtb.LinearityLinear,
+					MinBitRate:      1,
+					MaxBitRate:      1,
+					IsBoxingAllowed: true,
+					PlaybackMethods: []openrtb.PlaybackMethod{openrtb.PlaybackMethodAutoPlaySoundOn},
+					DeliveryMethods: []openrtb.DeliveryMethod{openrtb.DeliveryMethodProgressive},
+					Position:        openrtb.AdPositionAboveFold,
+					APIFrameworks:   []openrtb.APIFramework{openrtb.APIFrameworkVPAID1},
+				},
+				BidFloorPrice:      1.0,
+				BidFloorCurrency:   openrtb.CurrencyUSD,
+				PrivateMarketplace: &openrtb.PrivateMarketplace{},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		imp2 := testCase.impression.Copy()
+
+		if imp2 == testCase.impression {
+			t.Errorf("Address of impression should not be the same. impression1: %v impression2: %v", &testCase.impression, &imp2)
+		}
+
+		if testCase.impression.Video != nil {
+			if &testCase.impression.Video == &imp2.Video {
+				t.Errorf("Address of Video should not be the same in copied impression. Video1: %p Video2: %p.", testCase.impression.Video, imp2.Video)
+			}
+		}
+
+		if testCase.impression.PrivateMarketplace != nil {
+			if &testCase.impression.PrivateMarketplace == &imp2.PrivateMarketplace {
+				t.Errorf("Address of PrivateMarketplace should not be the same in copied impression. PrivateMarketplace1: %p PrivateMarketplace2: %p.", testCase.impression.PrivateMarketplace, imp2.PrivateMarketplace)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.impression, imp2) {
+			imp1JSON, _ := json.MarshalIndent(testCase.impression, "", "  ")
+			imp2JSON, _ := json.MarshalIndent(imp2, "", "  ")
+			t.Errorf("Impressions should hold the same values.\nExpected: %s\n Got: %s", imp1JSON, imp2JSON)
+		}
+		if diff := deep.Equal(testCase.impression, imp2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/privatemarketplace.go
+++ b/openrtb/privatemarketplace.go
@@ -9,3 +9,17 @@ type PrivateMarketplace struct {
 	IsPrivateAuction NumericBool `json:"private_auction"`
 	Deals            []*Deal     `json:"deals"`
 }
+
+// Copy returns a pointer to a copy of the Impression object.
+func (pmp *PrivateMarketplace) Copy() *PrivateMarketplace {
+	pmpCopy := *pmp
+
+	if pmp.Deals != nil {
+		pmpCopy.Deals = []*Deal{}
+		for i := range pmp.Deals {
+			pmpCopy.Deals = append(pmpCopy.Deals, pmp.Deals[i].Copy())
+		}
+	}
+
+	return &pmpCopy
+}

--- a/openrtb/privatemarketplace_test.go
+++ b/openrtb/privatemarketplace_test.go
@@ -1,0 +1,49 @@
+package openrtb_test
+
+import (
+	"testing"
+
+	"github.com/Vungle/vungo/openrtb"
+)
+
+func TestPrivateMarketplace_Copy(t *testing.T) {
+	testCases := []struct {
+		pmp *openrtb.PrivateMarketplace
+	}{
+		{
+			&openrtb.PrivateMarketplace{},
+		},
+		{
+			&openrtb.PrivateMarketplace{
+				IsPrivateAuction: true,
+				Deals: []*openrtb.Deal{
+					&openrtb.Deal{
+						ID:               "testDeal",
+						BidFloorPrice:    1.0,
+						BidFloorCurrency: "USD",
+						AuctionType:      openrtb.AuctionTypeSecondPrice,
+						WhitelistedSeats: []string{"1"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		pmp2 := testCase.pmp.Copy()
+
+		if pmp2 == testCase.pmp {
+			t.Errorf("Address of pmp should not be the same. pmp1: %v pmp2: %v", &testCase.pmp, &pmp2)
+		}
+
+		if &testCase.pmp.Deals == &pmp2.Deals {
+			t.Errorf("Address of deals should not be the same in copied private marketplace. Deals1: %p Deals2: %p.", testCase.pmp.Deals, pmp2.Deals)
+		}
+
+		for i := range testCase.pmp.Deals {
+			if &testCase.pmp.Deals[i] == &pmp2.Deals[i] {
+				t.Errorf("Address of deal should not be the same in copied private marketplace. Deal1: %p Deal2: %p.", testCase.pmp.Deals[i], pmp2.Deals[i])
+			}
+		}
+	}
+}

--- a/openrtb/publisher.go
+++ b/openrtb/publisher.go
@@ -11,3 +11,15 @@ type Publisher struct {
 	Categories []Category `json:"cat,omitempty"`
 	Domain     string     `json:"domain,omitempty"`
 }
+
+// Copy returns a pointer to a copy of the Publisher object.
+func (p *Publisher) Copy() *Publisher {
+	pubCopy := *p
+
+	if p.Categories != nil {
+		pubCopy.Categories = make([]Category, len(p.Categories))
+		copy(pubCopy.Categories, p.Categories)
+	}
+
+	return &pubCopy
+}

--- a/openrtb/publisher_test.go
+++ b/openrtb/publisher_test.go
@@ -4,12 +4,51 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
-var PublisherModelType = reflect.TypeOf(openrtb.Publisher{})
+var CategoriesModelType = reflect.TypeOf(openrtb.Publisher{})
 
-func TestPublisherMarshalUnmarshal(t *testing.T) {
-	openrtbtest.VerifyModelAgainstFile(t, "publisher.json", PublisherModelType)
+func TestCategoriesMarshalUnmarshal(t *testing.T) {
+	openrtbtest.VerifyModelAgainstFile(t, "publisher.json", CategoriesModelType)
+}
+
+func TestCategories_Copy(t *testing.T) {
+	testCases := []struct {
+		publisher *openrtb.Publisher
+	}{
+		{
+			&openrtb.Publisher{},
+		},
+		{
+			&openrtb.Publisher{
+				ID:         "testCategories",
+				Name:       "testName",
+				Categories: []openrtb.Category{openrtb.CategoryAdvertising},
+				Domain:     "testDomain",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		publisher2 := testCase.publisher.Copy()
+
+		if &publisher2.Categories == &testCase.publisher.Categories {
+			t.Errorf("Address of categories should not be the same in copied publisher. Categories1: %p Categories2: %p.", testCase.publisher.Categories, publisher2.Categories)
+		}
+
+		if !reflect.DeepEqual(testCase.publisher, publisher2) {
+			publisher1JSON, _ := json.MarshalIndent(testCase.publisher, "", "  ")
+			publisher2JSON, _ := json.MarshalIndent(publisher2, "", "  ")
+			t.Errorf("Videos should hold the same values.\nExpected: %s\n Got: %s", publisher1JSON, publisher2JSON)
+		}
+
+		if diff := deep.Equal(testCase.publisher, publisher2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/publisher_test.go
+++ b/openrtb/publisher_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/regulation.go
+++ b/openrtb/regulation.go
@@ -8,3 +8,14 @@ package openrtb
 type Regulation struct {
 	IsCoppaCompliant *NumericBool `json:"coppa,omitempty"`
 }
+
+// Copy returns a pointer to a copy of the Regulation object.
+func (r *Regulation) Copy() *Regulation {
+	regulationCopy := *r
+	if r.IsCoppaCompliant != nil {
+		coppaCopy := *r.IsCoppaCompliant
+		regulationCopy.IsCoppaCompliant = &coppaCopy
+	}
+
+	return &regulationCopy
+}

--- a/openrtb/regulation_test.go
+++ b/openrtb/regulation_test.go
@@ -4,12 +4,51 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var RegulationModelType = reflect.TypeOf(openrtb.Regulation{})
 
 func TestRegulationMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "regulation.json", RegulationModelType)
+}
+
+func TestRegulation_Copy(t *testing.T) {
+	testBool := openrtb.NumericBool(true)
+	testCases := []struct {
+		regulation *openrtb.Regulation
+	}{
+		{
+			&openrtb.Regulation{},
+		},
+		{
+			&openrtb.Regulation{
+				IsCoppaCompliant: &testBool,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		regulation2 := testCase.regulation.Copy()
+
+		if testCase.regulation.IsCoppaCompliant != nil {
+			if &testCase.regulation.IsCoppaCompliant == &regulation2.IsCoppaCompliant {
+				t.Errorf("Address of IsCoppaCompliant should not be the same in copied regulation. IsCoppaCompliant1: %p IsCoppaCompliant2: %p.", testCase.regulation.IsCoppaCompliant, regulation2.IsCoppaCompliant)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.regulation, regulation2) {
+			regulation1JSON, _ := json.MarshalIndent(testCase.regulation, "", "  ")
+			regulation2JSON, _ := json.MarshalIndent(regulation2, "", "  ")
+			t.Errorf("Regulations should hold the same values.\nExpected: %s\n Got: %s", regulation1JSON, regulation2JSON)
+		}
+
+		if diff := deep.Equal(testCase.regulation, regulation2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/regulation_test.go
+++ b/openrtb/regulation_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/user.go
+++ b/openrtb/user.go
@@ -16,3 +16,15 @@ type User struct {
 	Geo        *Geo        `json:"geo,omitempty"`
 	Extension  interface{} `json:"ext,omitempty"`
 }
+
+// Copy returns a pointer to a copy of the User object.
+func (u *User) Copy() *User {
+	userCopy := *u
+
+	if u.Geo != nil {
+		GeoCopy := *u.Geo
+		userCopy.Geo = &GeoCopy
+	}
+
+	return &userCopy
+}

--- a/openrtb/user_test.go
+++ b/openrtb/user_test.go
@@ -4,12 +4,66 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var UserModelType = reflect.TypeOf(openrtb.User{})
 
 func TestUserMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "user.json", UserModelType)
+}
+
+func TestUser_Copy(t *testing.T) {
+	testCases := []struct {
+		user *openrtb.User
+	}{
+		{
+			&openrtb.User{},
+		},
+		{
+			&openrtb.User{
+				ID:         "testUser",
+				BuyerID:    "testBuyerID",
+				BirthYear:  1,
+				Gender:     "testGender",
+				Keywords:   "testKeywords",
+				CustomData: "testCustomData",
+				Geo: &openrtb.Geo{
+					Latitude:  1,
+					Longitude: 1,
+					Type:      openrtb.GeoTypeGPS,
+					Country:   "testCountry",
+					Region:    "testRegion",
+					Metro:     "testMetro",
+					City:      "testCity",
+					ZipCode:   "123",
+					UTCOffset: 1,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		user2 := testCase.user.Copy()
+
+		if testCase.user.Geo != nil {
+			if &testCase.user.Geo == &user2.Geo {
+				t.Errorf("Address of Geo should not be the same in copied user. Geo1: %p Geo2: %p.", testCase.user.Geo, user2.Geo)
+			}
+		}
+
+		if !reflect.DeepEqual(testCase.user, user2) {
+			user1JSON, _ := json.MarshalIndent(testCase.user, "", "  ")
+			user2JSON, _ := json.MarshalIndent(user2, "", "  ")
+			t.Errorf("Users should hold the same values.\nExpected: %s\n Got: %s", user1JSON, user2JSON)
+		}
+
+		if diff := deep.Equal(testCase.user, user2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }

--- a/openrtb/user_test.go
+++ b/openrtb/user_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -38,3 +38,50 @@ func (v Video) Validate() error {
 	}
 	return nil
 }
+
+// Copy returns a pointer to a copy of the Video object.
+func (v *Video) Copy() *Video {
+	vCopy := *v
+
+	if v.MIMETypes != nil {
+		vCopy.MIMETypes = make([]string, len(v.MIMETypes))
+		copy(vCopy.MIMETypes, v.MIMETypes)
+	}
+
+	if v.MinDuration != nil {
+		minDurationCopy := *v.MinDuration
+		vCopy.MinDuration = &minDurationCopy
+	}
+
+	if v.MaxDuration != nil {
+		MaxDurationCopy := *v.MaxDuration
+		vCopy.MaxDuration = &MaxDurationCopy
+	}
+
+	if v.Protocols != nil {
+		vCopy.Protocols = make([]VideoProtocol, len(v.Protocols))
+		copy(vCopy.Protocols, v.Protocols)
+	}
+
+	if v.StartDelay != nil {
+		StartDelayCopy := *v.StartDelay
+		vCopy.StartDelay = &StartDelayCopy
+	}
+
+	if v.PlaybackMethods != nil {
+		vCopy.PlaybackMethods = make([]PlaybackMethod, len(v.PlaybackMethods))
+		copy(vCopy.PlaybackMethods, v.PlaybackMethods)
+	}
+
+	if v.DeliveryMethods != nil {
+		vCopy.DeliveryMethods = make([]DeliveryMethod, len(v.DeliveryMethods))
+		copy(vCopy.DeliveryMethods, v.DeliveryMethods)
+	}
+
+	if v.APIFrameworks != nil {
+		vCopy.APIFrameworks = make([]APIFramework, len(v.APIFrameworks))
+		copy(vCopy.APIFrameworks, v.APIFrameworks)
+	}
+
+	return &vCopy
+}

--- a/openrtb/video_test.go
+++ b/openrtb/video_test.go
@@ -1,10 +1,9 @@
 package openrtb_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"

--- a/openrtb/video_test.go
+++ b/openrtb/video_test.go
@@ -4,12 +4,93 @@ import (
 	"reflect"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/Vungle/vungo/openrtb"
 	"github.com/Vungle/vungo/openrtb/openrtbtest"
+	"github.com/go-test/deep"
 )
 
 var VideoModelType = reflect.TypeOf(openrtb.Video{})
 
 func TestVideoMarshalUnmarshal(t *testing.T) {
 	openrtbtest.VerifyModelAgainstFile(t, "video.json", VideoModelType)
+}
+
+func TestVideo_Copy(t *testing.T) {
+	testInt := 1
+	testCases := []struct {
+		video *openrtb.Video
+	}{
+		{
+			&openrtb.Video{},
+		},
+		{
+			&openrtb.Video{
+				MIMETypes:       []string{"testMime"},
+				MinDuration:     &testInt,
+				MaxDuration:     &testInt,
+				Protocols:       []openrtb.VideoProtocol{openrtb.VideoProtocolVAST2},
+				Width:           1,
+				Height:          1,
+				StartDelay:      &testInt,
+				Linearity:       openrtb.LinearityLinear,
+				MinBitRate:      1,
+				MaxBitRate:      1,
+				IsBoxingAllowed: true,
+				PlaybackMethods: []openrtb.PlaybackMethod{openrtb.PlaybackMethodAutoPlaySoundOn},
+				DeliveryMethods: []openrtb.DeliveryMethod{openrtb.DeliveryMethodProgressive},
+				Position:        openrtb.AdPositionAboveFold,
+				APIFrameworks:   []openrtb.APIFramework{openrtb.APIFrameworkVPAID1},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		video2 := testCase.video.Copy()
+
+		if testCase.video.MinDuration != nil {
+			if &testCase.video.MinDuration == &video2.MinDuration {
+				t.Errorf("Address of MinDuration should not be the same in copied video. MinDuration1: %p MinDuration2: %p.", testCase.video.MinDuration, video2.MinDuration)
+			}
+		}
+
+		if testCase.video.MaxDuration != nil {
+			if &testCase.video.MaxDuration == &video2.MaxDuration {
+				t.Errorf("Address of MaxDuration should not be the same in copied video. MaxDuration1: %p MaxDuration2: %p.", testCase.video.MaxDuration, video2.MaxDuration)
+			}
+		}
+
+		if &testCase.video.Protocols == &video2.Protocols {
+			t.Errorf("Address of protocols should not be the same in copied video. Protocols1: %p Protocols2: %p.", testCase.video.Protocols, video2.Protocols)
+		}
+
+		if testCase.video.StartDelay != nil {
+			if &testCase.video.StartDelay == &video2.StartDelay {
+				t.Errorf("Address of StartDelay should not be the same in copied video. StartDelay1: %p StartDelay2: %p.", testCase.video.StartDelay, video2.StartDelay)
+			}
+		}
+
+		if &testCase.video.PlaybackMethods == &video2.PlaybackMethods {
+			t.Errorf("Address of protocols should not be the same in copied video. PlaybackMethods1: %p PlaybackMethods2: %p.", testCase.video.PlaybackMethods, video2.PlaybackMethods)
+		}
+
+		if &testCase.video.DeliveryMethods == &video2.DeliveryMethods {
+			t.Errorf("Address of protocols should not be the same in copied video. DeliveryMethods1: %p DeliveryMethods2: %p.", testCase.video.DeliveryMethods, video2.DeliveryMethods)
+		}
+
+		if &testCase.video.APIFrameworks == &video2.APIFrameworks {
+			t.Errorf("Address of protocols should not be the same in copied video. APIFrameworks1: %p APIFrameworks2: %p.", testCase.video.APIFrameworks, video2.APIFrameworks)
+		}
+
+		if !reflect.DeepEqual(testCase.video, video2) {
+			video1JSON, _ := json.MarshalIndent(testCase.video, "", "  ")
+			video2JSON, _ := json.MarshalIndent(video2, "", "  ")
+			t.Errorf("Videos should hold the same values.\nExpected: %s\n Got: %s", video1JSON, video2JSON)
+		}
+
+		if diff := deep.Equal(testCase.video, video2); diff != nil {
+			t.Error(diff)
+		}
+	}
 }


### PR DESCRIPTION
# Context

There are possible cases where users will need to create a copy of the bid request for customization of the extension fields. This function allows for that since it will only copy all fields except extensions.

# Changes

* Creates a deep copy of the bid request that can be customized without modifying the original bid request.