### PR TITLE
fix(openrtb): strip out extensions in deep copy.

### DIFF
--- a/openrtb/application.go
+++ b/openrtb/application.go
@@ -51,5 +51,8 @@ func (a *Application) Copy() *Application {
 		appCopy.Publisher = a.Publisher.Copy()
 	}
 
+	// extension copying has to be done by the user of this package manually.
+	appCopy.Extension = nil
+
 	return &appCopy
 }

--- a/openrtb/application_test.go
+++ b/openrtb/application_test.go
@@ -42,8 +42,7 @@ func TestApplication_Copy(t *testing.T) {
 					Categories: []openrtb.Category{openrtb.CategoryAdvertising},
 					Domain:     "testDomain",
 				},
-				Keywords:  "testKeywords",
-				Extension: "testExtension",
+				Keywords: "testKeywords",
 			},
 		},
 	}

--- a/openrtb/device.go
+++ b/openrtb/device.go
@@ -59,6 +59,8 @@ func (d *Device) Copy() *Device {
 		SupportsJavaScriptCopy := *d.SupportsJavaScript
 		deviceCopy.SupportsJavaScript = &SupportsJavaScriptCopy
 	}
+	// extension copying has to be done by the user of this package manually.
+	deviceCopy.Extension = nil
 
 	return &deviceCopy
 }

--- a/openrtb/user.go
+++ b/openrtb/user.go
@@ -26,5 +26,8 @@ func (u *User) Copy() *User {
 		userCopy.Geo = &GeoCopy
 	}
 
+	// extension copying has to be done by the user of this package manually.
+	userCopy.Extension = nil
+
 	return &userCopy
 }


### PR DESCRIPTION
A fix to actually remove extensions from deep copy.