### PR TITLE
feat(openrtb): accept the bundle field in bid responses

### DIFF
--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -22,6 +22,7 @@ type BidResponse struct {
 	NoBidReason NoBidReason `json:"nbr,omitempty"`
 
 	RawExtension json.RawMessage `json:"ext,omitempty"`
+	Bundle       string          `json:"bundle,omitempty"`
 	Extension    interface{}     `json:"-"` // Opaque value that can be used to store unmarshaled value in ext field.
 }
 

--- a/openrtb/testdata/bidresponse.json
+++ b/openrtb/testdata/bidresponse.json
@@ -20,5 +20,6 @@
   "cur": "USD",
   "customdata": "A4(9GAKYMp@rGmhF!*bI6V0j/2#",
   "nbr": 2,
+  "bundle" : "com.appname.version",
   "ext": {"vungle":{"some":["arbitrary value","that","must be","compact JSON"]}}
 }


### PR DESCRIPTION
Adds the bundle field that is required for samsung support.