### PR TITLE
feat(vast): validate that there is at least one impression tracker in the VAST

### DIFF
--- a/vast/ad_test.go
+++ b/vast/ad_test.go
@@ -18,8 +18,8 @@ var adTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Ad{}, vast.ErrAdType, "ad.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_wrapper.xml"},
-	vasttest.VastTest{&vast.Ad{}, nil, "ad_error_inline.xml"},
-	vasttest.VastTest{&vast.Ad{}, nil, "ad_error_wrapper.xml"},
+	vasttest.VastTest{&vast.Ad{}, vast.ErrInlineMissImpressions, "ad_error_inline.xml"},
+	vasttest.VastTest{&vast.Ad{}, vast.ErrWrapperMissImpressions, "ad_error_wrapper.xml"},
 }
 
 func TestAdValidateErrors(t *testing.T) {

--- a/vast/inline.go
+++ b/vast/inline.go
@@ -48,15 +48,23 @@ func (inline *InLine) Validate() error {
 		errors = append(errors, ErrInlineMissImpressions)
 	}
 
-	// We don't want to over validate, as long as the first impression contains a valid tracker
+	// We don't want to over validate, as long as one impression contains a valid tracker
 	// we accept it.
-	if len(inline.Impressions) > 0 {
-		if err := inline.Impressions[0].Validate(); err != nil {
+	var impressionErr []error
+	for i := range inline.Impressions {
+		if err := inline.Impressions[i].Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {
-				errors = append(errors, ve.Errs...)
+				impressionErr = append(impressionErr, ve.Errs...)
 			}
+		} else {
+			impressionErr = nil
+			break
 		}
+	}
+
+	if len(impressionErr) > 0 {
+		errors = append(errors, impressionErr...)
 	}
 
 	for _, creative := range inline.Creatives {

--- a/vast/inline.go
+++ b/vast/inline.go
@@ -44,8 +44,14 @@ func (inline *InLine) Validate() error {
 		}
 	}
 
-	for _, impression := range inline.Impressions {
-		if err := impression.Validate(); err != nil {
+	if len(inline.Impressions) == 0 {
+		errors = append(errors, ErrInlineMissImpressions)
+	}
+
+	// We don't want to over validate, as long as the first impression contains a valid tracker
+	// we accept it.
+	if len(inline.Impressions) > 0 {
+		if err := inline.Impressions[0].Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {
 				errors = append(errors, ve.Errs...)

--- a/vast/inline.go
+++ b/vast/inline.go
@@ -48,25 +48,6 @@ func (inline *InLine) Validate() error {
 		errors = append(errors, ErrInlineMissImpressions)
 	}
 
-	// We don't want to over validate, as long as one impression contains a valid tracker
-	// we accept it.
-	var impressionErr []error
-	for i := range inline.Impressions {
-		if err := inline.Impressions[i].Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				impressionErr = append(impressionErr, ve.Errs...)
-			}
-		} else {
-			impressionErr = nil
-			break
-		}
-	}
-
-	if len(impressionErr) > 0 {
-		errors = append(errors, impressionErr...)
-	}
-
 	for _, creative := range inline.Creatives {
 		if err := creative.Validate(); err != nil {
 			ve, ok := err.(ValidationError)

--- a/vast/inline_test.go
+++ b/vast/inline_test.go
@@ -21,7 +21,7 @@ var inlineTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissImpressions, "inline_without_impressions.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrAdSystemMissSystem, "inline_without_adsystem.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrCreativeType, "inline_error_creatives.xml"},
-	vasttest.VastTest{&vast.InLine{}, vast.ErrImpressionMissUri, "inline_error_impressions.xml"},
+	vasttest.VastTest{&vast.InLine{}, nil, "inline_error_impressions.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrPricingCurrencyFormat, "inline_error_pricing.xml"},
 }
 

--- a/vast/inline_test.go
+++ b/vast/inline_test.go
@@ -18,7 +18,7 @@ var inlineTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.InLine{}, nil, "inline_valid.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissAdTitle, "inline_without_adtitle.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissCreatives, "inline_without_creatives.xml"},
-	vasttest.VastTest{&vast.InLine{}, nil, "inline_without_impressions.xml"},
+	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissImpressions, "inline_without_impressions.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrAdSystemMissSystem, "inline_without_adsystem.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrCreativeType, "inline_error_creatives.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrImpressionMissUri, "inline_error_impressions.xml"},

--- a/vast/wrapper.go
+++ b/vast/wrapper.go
@@ -29,8 +29,14 @@ func (w *Wrapper) Validate() error {
 		errors = append(errors, ErrWrapperMissVastAdTagUri)
 	}
 
-	for _, impression := range w.Impressions {
-		if err := impression.Validate(); err != nil {
+	if len(w.Impressions) == 0 {
+		errors = append(errors, ErrWrapperMissImpressions)
+	}
+
+	// We don't want to over validate, as long as the first impression contains a valid tracker
+	// we accept it.
+	if len(w.Impressions) > 0 {
+		if err := w.Impressions[0].Validate(); err != nil {
 			ve, ok := err.(ValidationError)
 			if ok {
 				errors = append(errors, ve.Errs...)

--- a/vast/wrapper.go
+++ b/vast/wrapper.go
@@ -33,25 +33,6 @@ func (w *Wrapper) Validate() error {
 		errors = append(errors, ErrWrapperMissImpressions)
 	}
 
-	// We don't want to over validate, as long as one impression contains a valid tracker
-	// we accept it.
-	var impressionErr []error
-	for i := range w.Impressions {
-		if err := w.Impressions[i].Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				impressionErr = append(impressionErr, ve.Errs...)
-			}
-		} else {
-			impressionErr = nil
-			break
-		}
-	}
-
-	if len(impressionErr) > 0 {
-		errors = append(errors, impressionErr...)
-	}
-
 	for _, c := range w.Creatives {
 		if err := c.Validate(); err != nil {
 			ve, ok := err.(ValidationError)

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -18,7 +18,7 @@ var wrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrIconResourcesFormat, "wrapper.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_valid.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrAdSystemMissSystem, "wrapper_error_adsystem.xml"},
-	vasttest.VastTest{&vast.Wrapper{}, vast.ErrImpressionMissUri, "wrapper_error_impression.xml"},
+	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_error_impression.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissVastAdTagUri, "wrapper_without_adtaguri.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissImpressions, "wrapper_without_impression.xml"},
 }

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -20,7 +20,7 @@ var wrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrAdSystemMissSystem, "wrapper_error_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrImpressionMissUri, "wrapper_error_impression.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissVastAdTagUri, "wrapper_without_adtaguri.xml"},
-	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_without_impression.xml"},
+	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissImpressions, "wrapper_without_impression.xml"},
 }
 
 func TestWrapperValidateErrors(t *testing.T) {


### PR DESCRIPTION
Some advertisers don't fully abide by the standard and have empty tags when passing impressions. Rather than being extremely strict with validation, we just validate that there is one valid impression. This will at least leave the responsibility to the advertiser that they are passing empty impressions and allowing us to use "valid" VAST.