### PR TITLE
JAE-1175: fix(companionAd, validation) disregard CompanionAd tag in RTB response

### DIFF
--- a/vast/companionads.go
+++ b/vast/companionads.go
@@ -9,9 +9,6 @@ type CompanionAds struct {
 // Validate methods validate the CompanionAds element according to the VAST.
 func (companionAds *CompanionAds) Validate() error {
 	errors := make([]error, 0)
-	if len(companionAds.Companions) == 0 {
-		errors = append(errors, ErrCompanionAdsMissCompanions)
-	}
 
 	if len(companionAds.Required) != 0 {
 		if err := companionAds.Required.Validate(); err != nil {

--- a/vast/companionads_test.go
+++ b/vast/companionads_test.go
@@ -15,7 +15,7 @@ func TestCompanionAdsMarshalUnmarshal(t *testing.T) {
 }
 
 var companionAdsTests = []vasttest.VastTest{
-	vasttest.VastTest{&vast.CompanionAds{}, vast.ErrCompanionAdsMissCompanions, "companionads_without_companion.xml"},
+	vasttest.VastTest{&vast.CompanionAds{}, nil, "companionads_without_companion.xml"},
 	vasttest.VastTest{&vast.CompanionAds{}, nil, "companionads_valid.xml"},
 	vasttest.VastTest{&vast.CompanionAds{}, nil, "companionads.xml"},
 	vasttest.VastTest{&vast.CompanionAds{}, vast.ErrUnsupportedMode, "companionads_error_required.xml"},

--- a/vast/creative_test.go
+++ b/vast/creative_test.go
@@ -25,7 +25,7 @@ var creativeTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Creative{}, vast.ErrCreativeType, "creative_without_ads.xml"},
 	vasttest.VastTest{&vast.Creative{}, vast.ErrLinearMissMediaFiles, "creative_error_linear.xml"},
 	vasttest.VastTest{&vast.Creative{}, vast.ErrNonLinearAdsMissNonLinears, "creative_error_nonlinearads.xml"},
-	vasttest.VastTest{&vast.Creative{}, vast.ErrCompanionAdsMissCompanions, "creative_error_companionads.xml"},
+	vasttest.VastTest{&vast.Creative{}, nil, "creative_error_companionads.xml"},
 }
 
 func TestCreativeValidateErrors(t *testing.T) {


### PR DESCRIPTION
# Context
We currently reject bids that respond with companion ad tags. We do not support companion ads and therefore does not apply to the validation before we accept a bid response.
https://vungle.atlassian.net/browse/JAE-1175

# Acceptance
Possibly a sizable increase in accepted bid responses now that validation logic disregards checks for companionAd tag.

# Changes
* removed check for companionAds in companionAds.Validate()
* updated unit test for corresponding validation changes 