### PR TITLE
fix(user): fix user so that the id is not mandatory

### DIFF
--- a/openrtb/user.go
+++ b/openrtb/user.go
@@ -7,7 +7,7 @@ package openrtb
 //go:generate easyjson $GOFILE
 //easyjson:json
 type User struct {
-	ID         string      `json:"id"`
+	ID         string      `json:"id,omitempty"`
 	BuyerID    string      `json:"buyeruid,omitempty"`
 	BirthYear  int         `json:"yob,omitempty"`
 	Gender     Gender      `json:"gender,omitempty"`


### PR DESCRIPTION
# Context

Check open-rtb spec 2.3 Section 3.2.13
https://www.iab.com/wp-content/uploads/2015/06/OpenRTB-API-Specification-Version-2-3.pdf

The `Id` for user object is a recommended field and not a required field. This change is to fix the openrtb implementation to make it optional.

# Changes

Add `omitempty` as tag to the `id`