### PR TITLE
fix(regulation): Add extension field to regulation

### DIFF
--- a/openrtb/regulation.go
+++ b/openrtb/regulation.go
@@ -7,6 +7,7 @@ package openrtb
 //easyjson:json
 type Regulation struct {
 	IsCoppaCompliant *NumericBool `json:"coppa,omitempty"`
+	Extension        interface{}  `json:"ext,omitempty"`
 }
 
 // Copy returns a pointer to a copy of the Regulation object.

--- a/openrtb/testdata/regulation.json
+++ b/openrtb/testdata/regulation.json
@@ -1,3 +1,6 @@
 {
-  "coppa": 1
+  "coppa": 1,
+  "ext": {
+    "gdpr": 1
+  }
 }


### PR DESCRIPTION
# Context
Check open-rtb spec 2.3 Section 3.2.16
https://www.iab.com/wp-content/uploads/2015/06/OpenRTB-API-Specification-Version-2-3.pdf

Regulation in openrtb 2.3.1 requires an extension field. This PR will enable it in the library.

# Changes
Add `ext` field to regulation. This will help with adding GDPR fields as per https://iabtechlab.com/wp-content/uploads/2018/02/OpenRTB_Advisory_GDPR_2018-02.pdf