### PR TITLE
fix(ad): minor fix in ad validation.

### DIFF
--- a/vast/ad.go
+++ b/vast/ad.go
@@ -16,29 +16,46 @@ type Ad struct {
 // Each <Ad> contains either EXACTLY ONE <InLine> element or <Wrapper> element (but never both).
 func (ad *Ad) Validate() error {
 	errors := make([]error, 0)
-	if ad.InLine != nil {
-		if ad.Wrapper != nil {
-			errors = append(errors, ErrAdType)
-		}
-		if err := ad.InLine.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	} else {
-		if ad.Wrapper == nil {
-			errors = append(errors, ErrAdType)
-		}
-		if err := ad.Wrapper.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
+
+	if ad.InLine != nil && ad.Wrapper != nil {
+		errors = append(errors, ErrAdType)
+		return ValidationError{Errs: errors}
 	}
+
+	if ad.InLine != nil {
+		errors = append(errors, ad.validateInline()...)
+	} else if ad.Wrapper != nil {
+		errors = append(errors, ad.validateWrapper()...)
+	} else {
+		errors = append(errors, ErrAdType)
+	}
+
 	if len(errors) > 0 {
 		return ValidationError{Errs: errors}
 	}
 	return nil
+}
+
+func (ad *Ad) validateInline() []error {
+	errors := make([]error, 0)
+	if err := ad.InLine.Validate(); err != nil {
+		ve, ok := err.(ValidationError)
+		if ok {
+			errors = append(errors, ve.Errs...)
+		}
+	}
+
+	return errors
+}
+
+func (ad *Ad) validateWrapper() []error {
+	errors := make([]error, 0)
+	if err := ad.Wrapper.Validate(); err != nil {
+		ve, ok := err.(ValidationError)
+		if ok {
+			errors = append(errors, ve.Errs...)
+		}
+	}
+
+	return errors
 }

--- a/vast/ad_test.go
+++ b/vast/ad_test.go
@@ -18,6 +18,7 @@ var adTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Ad{}, vast.ErrAdType, "ad.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, nil, "ad_with_wrapper.xml"},
+	vasttest.VastTest{&vast.Ad{}, vast.ErrAdType, "ad_no_wrapper_no_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, vast.ErrInlineMissImpressions, "ad_error_inline.xml"},
 	vasttest.VastTest{&vast.Ad{}, vast.ErrWrapperMissImpressions, "ad_error_wrapper.xml"},
 }

--- a/vast/errors.go
+++ b/vast/errors.go
@@ -60,6 +60,8 @@ var (
 
 	ErrMediaFileWidthTooLow = errors.New("The width of the MediaFile is too low")
 
+	ErrMissAdInline = errors.New("Ad should only contain one of Inline and Wrapper")
+
 	ErrNonLinearAdsMissNonLinears = errors.New("NonLinearAds miss NonLinears")
 
 	ErrNonLinearResourceFormat = errors.New("NonLinear resources should contain only one of StaticResource, IFrameResource, HtmlResource")

--- a/vast/testdata/ad_no_wrapper_no_inline.xml
+++ b/vast/testdata/ad_no_wrapper_no_inline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Ad id="some-id" sequence="2">
+</Ad>


### PR DESCRIPTION
# Context

There is a missed check for Wrapper when it is nil. The validation would catch it, but not return.