### PR TITLE
fix(vast): Remove system validation.

### DIFF
--- a/vast/inline.go
+++ b/vast/inline.go
@@ -20,14 +20,7 @@ type InLine struct {
 // AdSystem, AdTitle, Impression, Creatives are required.
 func (inline *InLine) Validate() error {
 	errors := make([]error, 0)
-	if inline.AdSystem != nil {
-		if err := inline.AdSystem.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	} else {
+	if inline.AdSystem == nil {
 		errors = append(errors, ErrInlineMissAdSystem)
 	}
 

--- a/vast/inline.go
+++ b/vast/inline.go
@@ -20,10 +20,6 @@ type InLine struct {
 // AdSystem, AdTitle, Impression, Creatives are required.
 func (inline *InLine) Validate() error {
 	errors := make([]error, 0)
-	if inline.AdSystem == nil {
-		errors = append(errors, ErrInlineMissAdSystem)
-	}
-
 	if inline.AdTitle == nil {
 		errors = append(errors, ErrInlineMissAdTitle)
 	}

--- a/vast/inline_test.go
+++ b/vast/inline_test.go
@@ -16,7 +16,6 @@ func TestInLineMarshalUnmarshal(t *testing.T) {
 
 var inlineTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.InLine{}, nil, "inline_valid.xml"},
-	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissAdSystem, "inline_without_adsystem.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissAdTitle, "inline_without_adtitle.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissCreatives, "inline_without_creatives.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissImpressions, "inline_without_impressions.xml"},

--- a/vast/inline_test.go
+++ b/vast/inline_test.go
@@ -20,7 +20,6 @@ var inlineTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissAdTitle, "inline_without_adtitle.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissCreatives, "inline_without_creatives.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrInlineMissImpressions, "inline_without_impressions.xml"},
-	vasttest.VastTest{&vast.InLine{}, vast.ErrAdSystemMissSystem, "inline_adsystem_without_system.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrCreativeType, "inline_error_creatives.xml"},
 	vasttest.VastTest{&vast.InLine{}, nil, "inline_error_impressions.xml"},
 	vasttest.VastTest{&vast.InLine{}, vast.ErrPricingCurrencyFormat, "inline_error_pricing.xml"},

--- a/vast/wrapper.go
+++ b/vast/wrapper.go
@@ -18,14 +18,7 @@ type Wrapper struct {
 // Creatives are optional, if it exists, we'll also validate it.
 func (w *Wrapper) Validate() error {
 	errors := make([]error, 0)
-	if w.AdSystem != nil {
-		if err := w.AdSystem.Validate(); err != nil {
-			ve, ok := err.(ValidationError)
-			if ok {
-				errors = append(errors, ve.Errs...)
-			}
-		}
-	} else {
+	if w.AdSystem == nil {
 		errors = append(errors, ErrWrapperMissAdSystem)
 	}
 

--- a/vast/wrapper.go
+++ b/vast/wrapper.go
@@ -18,10 +18,6 @@ type Wrapper struct {
 // Creatives are optional, if it exists, we'll also validate it.
 func (w *Wrapper) Validate() error {
 	errors := make([]error, 0)
-	if w.AdSystem == nil {
-		errors = append(errors, ErrWrapperMissAdSystem)
-	}
-
 	if len(w.VastAdTagUri) == 0 {
 		errors = append(errors, ErrWrapperMissVastAdTagUri)
 	}

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -17,7 +17,6 @@ func TestWrapperMarshalUnmarshal(t *testing.T) {
 var wrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrIconResourcesFormat, "wrapper.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_valid.xml"},
-	vasttest.VastTest{&vast.Wrapper{}, vast.ErrAdSystemMissSystem, "wrapper_error_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_error_impression.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissAdSystem, "wrapper_without_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissVastAdTagUri, "wrapper_without_adtaguri.xml"},

--- a/vast/wrapper_test.go
+++ b/vast/wrapper_test.go
@@ -18,7 +18,6 @@ var wrapperTests = []vasttest.VastTest{
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrIconResourcesFormat, "wrapper.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_valid.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, nil, "wrapper_error_impression.xml"},
-	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissAdSystem, "wrapper_without_adsystem.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissVastAdTagUri, "wrapper_without_adtaguri.xml"},
 	vasttest.VastTest{&vast.Wrapper{}, vast.ErrWrapperMissImpressions, "wrapper_without_impression.xml"},
 }


### PR DESCRIPTION
# Context
AdSystem is required per the RTB spec, but we shouldn't reject as long as a value exists in at least one level of the VAST. We should Remove the system validation. 

https://vungle.atlassian.net/browse/JAE-1444

# Changes

* Remove AdSystem validation.
* update tests.