### PR TITLE
feat(openrtb): Add extension field to video.

### DIFF
--- a/openrtb/testdata/video.json
+++ b/openrtb/testdata/video.json
@@ -13,5 +13,6 @@
   "playbackmethod": [1, 2],
   "delivery": [1, 2],
   "pos": 30,
-  "api": [1, 2]
+  "api": [1, 2],
+  "ext":{"videotype":"rewarded","skip":1}
 }

--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -24,6 +24,7 @@ type Video struct {
 	DeliveryMethods []DeliveryMethod `json:"delivery,omitempty"`
 	Position        AdPosition       `json:"pos,omitempty"`
 	APIFrameworks   []APIFramework   `json:"api,omitempty"`
+	Extension       interface{}      `json:"ext,omitempty"`
 }
 
 // Validate method implements a Validater interface and return a validation error according to the
@@ -82,6 +83,9 @@ func (v *Video) Copy() *Video {
 		vCopy.APIFrameworks = make([]APIFramework, len(v.APIFrameworks))
 		copy(vCopy.APIFrameworks, v.APIFrameworks)
 	}
+
+	// extension copying has to be done by the user of this package manually.
+	vCopy.Extension = nil
 
 	return &vCopy
 }


### PR DESCRIPTION
# Context
Check open-rtb spec 2.5 Section 3.2.7
https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf
Video in openrtb 2.5 has an extension field. This PR will enable it in the library.

# Changes

- Add `ext` field to Video elements. 

- Update UT accordingly.