### PR TITLE
fix(vast): Remove  validation error for event.

### DIFF
--- a/vast/event.go
+++ b/vast/event.go
@@ -26,29 +26,9 @@ const (
 	EVENT_PROGRESS          Event = "progress" // VAST3.0.
 )
 
+// Validate function returns error of event.
+// We do not do the strict validation. If the event type is not defined, just skipped it rather than return validate failure.
+// Please refer to https://vungle.atlassian.net/browse/PBJ-685 for more details.
 func (e Event) Validate() error {
-	switch e {
-	case EVENT_CREATIVE_VIEW:
-	case EVENT_START:
-	case EVENT_FIRST_QUARTILE:
-	case EVENT_MIDPOINT:
-	case EVENT_THIRD_QUARTILE:
-	case EVENT_COMPLETE:
-	case EVENT_MUTE:
-	case EVENT_UNMUTE:
-	case EVENT_PAUSE:
-	case EVENT_REWIND:
-	case EVENT_RESUME:
-	case EVENT_FULLSCREEN:
-	case EVENT_EXIT_FULLSCREEN:
-	case EVENT_EXPAND:
-	case EVENT_COLLAPSE:
-	case EVENT_ACCEPT_INVITATION:
-	case EVENT_CLOSE:
-	case EVENT_SKIP:
-	case EVENT_PROGRESS:
-	default:
-		return ValidationError{Errs: []error{ErrUnsupportedEvent}}
-	}
 	return nil
 }

--- a/vast/event.go
+++ b/vast/event.go
@@ -26,9 +26,32 @@ const (
 	EVENT_PROGRESS          Event = "progress" // VAST3.0.
 )
 
-// Validate function returns error of event.
-// We do not do the strict validation. If the event type is not defined, just skipped it rather than return validate failure.
-// Please refer to https://vungle.atlassian.net/browse/PBJ-685 for more details.
 func (e Event) Validate() error {
+	switch e {
+	case EVENT_CREATIVE_VIEW:
+	case EVENT_START:
+	case EVENT_FIRST_QUARTILE:
+	case EVENT_MIDPOINT:
+	case EVENT_THIRD_QUARTILE:
+	case EVENT_COMPLETE:
+	case EVENT_MUTE:
+	case EVENT_UNMUTE:
+	case EVENT_PAUSE:
+	case EVENT_REWIND:
+	case EVENT_RESUME:
+	case EVENT_FULLSCREEN:
+	case EVENT_EXIT_FULLSCREEN:
+	case EVENT_EXPAND:
+	case EVENT_COLLAPSE:
+	case EVENT_ACCEPT_INVITATION:
+	case EVENT_CLOSE:
+	case EVENT_SKIP:
+	case EVENT_PROGRESS:
+	default:
+		// Validate function returns error of event.
+		// We do not do the strict validation. If the event type is not defined, just skipped it rather than return validate failure.
+		// Please refer to https://vungle.atlassian.net/browse/PBJ-685 for more details.
+		return nil
+	}
 	return nil
 }

--- a/vast/event_test.go
+++ b/vast/event_test.go
@@ -27,6 +27,8 @@ var eventTests = []vasttest.VastTest{
 	vasttest.VastTest{vast.Event(vast.EVENT_CLOSE), nil, ""},
 	vasttest.VastTest{vast.Event(vast.EVENT_SKIP), nil, ""},
 	vasttest.VastTest{vast.Event(vast.EVENT_PROGRESS), nil, ""},
+	vasttest.VastTest{vast.Event("test"), nil, ""},
+	vasttest.VastTest{vast.Event(""), nil, ""},
 }
 
 func TestEventValidateErrors(t *testing.T) {

--- a/vast/event_test.go
+++ b/vast/event_test.go
@@ -27,8 +27,6 @@ var eventTests = []vasttest.VastTest{
 	vasttest.VastTest{vast.Event(vast.EVENT_CLOSE), nil, ""},
 	vasttest.VastTest{vast.Event(vast.EVENT_SKIP), nil, ""},
 	vasttest.VastTest{vast.Event(vast.EVENT_PROGRESS), nil, ""},
-	vasttest.VastTest{vast.Event("test"), vast.ErrUnsupportedEvent, ""},
-	vasttest.VastTest{vast.Event(""), vast.ErrUnsupportedEvent, ""},
 }
 
 func TestEventValidateErrors(t *testing.T) {


### PR DESCRIPTION
# Context

This PR removes the validation errors for event.

https://vungle.atlassian.net/browse/PBJ-685

We should not do the strict validation. If the event type is not defined, just skipped it rather than return validate failure.

# Acceptance

- No validate failure returns if the event type is unknown.


# Changes

* The validation of event always return no error.
* Update test.

