### PR TITLE
feat(openrtb)[PBJ-686]: Allow publishers to block certain advertising apps by MarketID

### DIFF
--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -24,8 +24,7 @@ type BidRequest struct {
 	Currencies                   []Currency    `json:"cur,omitempty"`
 	BlockedCategories            []Category    `json:"bcat,omitempty"`
 	BlockedAdvertisers           []string      `json:"badv,omitempty"`
-	// bapp is for OpenRTB 2.5 or above
-	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"`
+	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"` // bapp is for OpenRTB 2.5 onwards
 	Regulation                   *Regulation   `json:"regs,omitempty"`
 }
 

--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -24,6 +24,7 @@ type BidRequest struct {
 	Currencies                   []Currency    `json:"cur,omitempty"`
 	BlockedCategories            []Category    `json:"bcat,omitempty"`
 	BlockedAdvertisers           []string      `json:"badv,omitempty"`
+	// bapp is for OpenRTB 2.5 or above
 	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"`
 	Regulation                   *Regulation   `json:"regs,omitempty"`
 }

--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -11,20 +11,21 @@ import (
 //go:generate easyjson $GOFILE
 //easyjson:json
 type BidRequest struct {
-	ID                 string        `json:"id"`
-	Impressions        []*Impression `json:"imp"`
-	Application        *Application  `json:"app,omitempty"`
-	Device             *Device       `json:"device,omitempty"`
-	User               *User         `json:"user,omitempty"`
-	IsTestMode         NumericBool   `json:"test,omitempty"`
-	AuctionType        AuctionType   `json:"at"`
-	Timeout            int           `json:"tmax,omitempty"`
-	WhitelistedSeats   []string      `json:"wseat,omitempty"`
-	HasAllImpressions  NumericBool   `json:"allimps,omitempty"`
-	Currencies         []Currency    `json:"cur,omitempty"`
-	BlockedCategories  []Category    `json:"bcat,omitempty"`
-	BlockedAdvertisers []string      `json:"badv,omitempty"`
-	Regulation         *Regulation   `json:"regs,omitempty"`
+	ID                           string        `json:"id"`
+	Impressions                  []*Impression `json:"imp"`
+	Application                  *Application  `json:"app,omitempty"`
+	Device                       *Device       `json:"device,omitempty"`
+	User                         *User         `json:"user,omitempty"`
+	IsTestMode                   NumericBool   `json:"test,omitempty"`
+	AuctionType                  AuctionType   `json:"at"`
+	Timeout                      int           `json:"tmax,omitempty"`
+	WhitelistedSeats             []string      `json:"wseat,omitempty"`
+	HasAllImpressions            NumericBool   `json:"allimps,omitempty"`
+	Currencies                   []Currency    `json:"cur,omitempty"`
+	BlockedCategories            []Category    `json:"bcat,omitempty"`
+	BlockedAdvertisers           []string      `json:"badv,omitempty"`
+	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"`
+	Regulation                   *Regulation   `json:"regs,omitempty"`
 }
 
 // Validate method checks to see if the BidRequest object contains required and well-formatted data

--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -24,7 +24,7 @@ type BidRequest struct {
 	Currencies                   []Currency    `json:"cur,omitempty"`
 	BlockedCategories            []Category    `json:"bcat,omitempty"`
 	BlockedAdvertisers           []string      `json:"badv,omitempty"`
-	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"` // bapp is for OpenRTB 2.5 onwards
+	BlockedAdvertisersByMarketID []string      `json:"bapp,omitempty"` // bapp is for OpenRTB 2.5 onwards.
 	Regulation                   *Regulation   `json:"regs,omitempty"`
 }
 

--- a/openrtb/bidrequest_test.go
+++ b/openrtb/bidrequest_test.go
@@ -150,12 +150,13 @@ func TestBidRequest_Copy(t *testing.T) {
 						UTCOffset: 1,
 					},
 				},
-				AuctionType:        1,
-				Timeout:            1,
-				WhitelistedSeats:   []string{"1"},
-				Currencies:         []openrtb.Currency{openrtb.CurrencyUSD},
-				BlockedCategories:  []openrtb.Category{openrtb.Category712Education},
-				BlockedAdvertisers: []string{"advertiser1"},
+				AuctionType:                  1,
+				Timeout:                      1,
+				WhitelistedSeats:             []string{"1"},
+				Currencies:                   []openrtb.Currency{openrtb.CurrencyUSD},
+				BlockedCategories:            []openrtb.Category{openrtb.Category712Education},
+				BlockedAdvertisers:           []string{"advertiser1"},
+				BlockedAdvertisersByMarketID: []string{"403639508", "479706646"},
 				Regulation: &openrtb.Regulation{
 					IsCoppaCompliant: &testBool,
 				},
@@ -214,6 +215,10 @@ func TestBidRequest_Copy(t *testing.T) {
 
 		if &testCase.bidrequest.BlockedAdvertisers == &b2.BlockedAdvertisers {
 			t.Errorf("Address of blocked advertisers should not be the same in copied bidrequest. BlockedAdvertisers1: %p BlockedAdvertisers2: %p.", testCase.bidrequest.BlockedAdvertisers, b2.BlockedAdvertisers)
+		}
+
+		if &testCase.bidrequest.BlockedAdvertisersByMarketID == &b2.BlockedAdvertisersByMarketID {
+			t.Errorf("Address of blocked advertisers MarketID should not be the same in copied bidrequest. BlockedAdvertisersByMarketID1: %p BlockedAdvertisersByMarketID2: %p.", testCase.bidrequest.BlockedAdvertisersByMarketID, b2.BlockedAdvertisersByMarketID)
 		}
 
 		if testCase.bidrequest.Regulation != nil {

--- a/openrtb/testdata/bidrequest.json
+++ b/openrtb/testdata/bidrequest.json
@@ -119,6 +119,7 @@
   "allimps": 1,
   "wseat": ["111", "1ab"],
   "badv": ["supercell.com", "machinezone.com"],
+  "bapp": ["403639508","479706646"],
   "cur": ["USD", "CNY"],
   "bcat": ["IAB7-39"],
   "regs": {


### PR DESCRIPTION
# Context
This PR adds bapp field for Openrtb bid request.
The field is a string array which represents block list of applications by their platform-specific exchange independent application identifiers. On Android, these should be bundle or package names (e.g., com.foo.mygame). On iOS, these are numeric IDs. We call it MarketID regardless of the platform in the context. 
Please refer to https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf for spec detail.

https://vungle.atlassian.net/browse/PBJ-686


# Acceptance
If when creating the market ID, marketID black list is pass in, it should contain field after bid request constructed.

Changes
Added a new field BlockedAdvertisersByMarketID to BidRequest struct.
Updated related UT accordingly.
