### PR TITLE
fix(openrtb)[PBJ-1389]: Non-required pointer fields should be omitempty

### DIFF
--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -230,7 +230,7 @@ type Video struct {
 	// Description:
 	//   Array of Banner objects (Section 3.2.6) if companion ads are
 	//   available.
-	CompanionAds []Banner `json:"companionad"`
+	CompanionAds []Banner `json:"companionad,omitempty"`
 
 	// Attribute:
 	//   api
@@ -252,7 +252,7 @@ type Video struct {
 	//   the companionad array. If one of these banners will be
 	//   rendered as an end-card, this can be specified using the vcm
 	//   attribute with the particular banner (Section 3.2.6).
-	CompanionTypes []CompanionType `json:"companiontype"`
+	CompanionTypes []CompanionType `json:"companiontype,omitempty"`
 
 	// Attribute:
 	//   ext


### PR DESCRIPTION
* Add omitempty for Video companionad and companiontype.
* Double check all new added fields for OpenRTB 2.5 and no other fields without necessary omitempty.

Issue description:
OpenX will reply 500 if bid request video contains
        "companionad": null,
        "companiontype": null,