### PR TITLE
Use filepath api instead of regex when validate uri of mediafile.

### DIFF
--- a/vast/mediafile.go
+++ b/vast/mediafile.go
@@ -2,7 +2,7 @@ package vast
 
 import (
 	"net/url"
-	"regexp"
+	"path/filepath"
 	"strings"
 
 	"github.com/Vungle/vungo/vast/defaults"
@@ -90,18 +90,15 @@ func (mediaFile *MediaFile) Validate() error {
 	return nil
 }
 
-// The regex will check if the given path string has .mp4 extension.
-var re = regexp.MustCompile(`^([^#])+\.mp4$`)
-
 func checkMediaFileURI(uri TrimmedData) error {
 	u, err := url.Parse(string(uri))
 	if err != nil {
 		return ErrorInvalidMediaFileURI
 	}
-	if strings.ToLower(u.Scheme) != "http" && strings.ToLower(u.Scheme) != "https" {
+	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
 		return ErrorInvalidMediaFileURI
 	}
-	if !re.MatchString(strings.ToLower(u.Path)) {
+	if !strings.EqualFold(filepath.Ext(u.Path), ".mp4") {
 		return ErrorInvalidMediaFileURI
 	}
 	return nil


### PR DESCRIPTION
Use filepath api instead of regex to make the code more readable.