### PR TITLE
Add CompanionClickTracking support.

### DIFF
--- a/vast/companion.go
+++ b/vast/companion.go
@@ -13,6 +13,7 @@ type Companion struct {
 	AdSlotId       string `xml:"adSlotId,attr,omitempty"` // VAST3.0.
 
 	ClickThrough   string          `xml:"CompanionClickThrough,omitempty"`
+	ClickTracking  string          `xml:"CompanionClickTracking,omitempty"` // VAST3.0.
 	AltText        string          `xml:"AltText,omitempty"`
 	Trackings      []*Tracking     `xml:"TrackingEvents>Tracking,omitempty"` // Required tracking: EVENT_CREATIVE_VIEW
 	AdParameters   *AdParameters   `xml:"AdParameters,omitempty"`            // Just string in VAST2.0.

--- a/vast/testdata/companion.xml
+++ b/vast/testdata/companion.xml
@@ -10,6 +10,7 @@
     apiFramework="Vungle Exchange"
     adSlotId="ad-slot-id">
   <CompanionClickThrough><![CDATA[http://clickthrough/url]]></CompanionClickThrough>
+  <CompanionClickTracking><![CDATA[http://ClickTracking/url]]></CompanionClickTracking>
   <AltText><![CDATA[Alt text for HTML rendering.]]></AltText>
   <TrackingEvents>
     <Tracking event="mute"><![CDATA[http://mute/me]]></Tracking>


### PR DESCRIPTION
CompanionClickTracking has been defined since VAST 3.0

https://www.iab.com/wp-content/uploads/2015/06/VASTv3_0.pdf 
Please see chapter 2.3.3.7 for details.