### PR TITLE
Add  OMID API frameworks support.

### DIFF
--- a/openrtb/apiframework.go
+++ b/openrtb/apiframework.go
@@ -12,4 +12,5 @@ const (
 	APIFrameworkORMMA  APIFramework = 4 // ORMMA
 	APIFrameworkMRAID2 APIFramework = 5 // MRAID-2
 	APIFrameworkMRAID3 APIFramework = 6 // MRAID-3
+	APIFrameworkOMID1  APIFramework = 7 // OMID-1
 )


### PR DESCRIPTION
Use 7 as the value to indicate OMID support.
See more OMID support details from
https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/master/OpenRTB%20support%20for%20OMSDK.md#om-sdk-support-in-openrtb-version-20-to-25