### PR TITLE
feat(openrtb): Change Bid Response NoServReason Type to Pointer

### DIFF
--- a/openrtb/bidresponse.go
+++ b/openrtb/bidresponse.go
@@ -16,12 +16,12 @@ var emptyBid BidResponse
 //go:generate easyjson $GOFILE
 //easyjson:json
 type BidResponse struct {
-	ID          string      `json:"id"`
-	SeatBids    []*SeatBid  `json:"seatbid,omitempty"`
-	BidID       string      `json:"bidid,omitempty"`
-	Currency    Currency    `json:"cur,omitempty"`
-	CustomData  string      `json:"customdata,omitempty"`
-	NoBidReason NoBidReason `json:"nbr,omitempty"`
+	ID          string       `json:"id"`
+	SeatBids    []*SeatBid   `json:"seatbid,omitempty"`
+	BidID       string       `json:"bidid,omitempty"`
+	Currency    Currency     `json:"cur,omitempty"`
+	CustomData  string       `json:"customdata,omitempty"`
+	NoBidReason *NoBidReason `json:"nbr,omitempty"`
 
 	RawExtension json.RawMessage `json:"ext,omitempty"`
 	Extension    interface{}     `json:"-"` // Opaque value that can be used to store unmarshaled value in ext field.
@@ -39,6 +39,9 @@ func (r *BidResponse) Validate() error {
 	}
 
 	if len(r.SeatBids) == 0 {
+		if r.NoBidReason == nil {
+			return ErrInvalidNoBidReason
+		}
 		return r.NoBidReason.Validate()
 	}
 
@@ -71,6 +74,9 @@ func (r *BidResponse) Copy() *BidResponse {
 	}
 
 	brCopy := *r
+	if r.NoBidReason != nil {
+		brCopy.NoBidReason = r.NoBidReason.Ref()
+	}
 
 	if r.SeatBids != nil {
 		brCopy.SeatBids = make([]*SeatBid, len(r.SeatBids))

--- a/openrtb/bidresponse_easyjson.go
+++ b/openrtb/bidresponse_easyjson.go
@@ -76,7 +76,15 @@ func easyjson10eb023eDecodeGithubComVungleVungoOpenrtb(in *jlexer.Lexer, out *Bi
 		case "customdata":
 			out.CustomData = string(in.String())
 		case "nbr":
-			out.NoBidReason = NoBidReason(in.Int())
+			if in.IsNull() {
+				in.Skip()
+				out.NoBidReason = nil
+			} else {
+				if out.NoBidReason == nil {
+					out.NoBidReason = new(NoBidReason)
+				}
+				*out.NoBidReason = NoBidReason(in.Int())
+			}
 		case "ext":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.RawExtension).UnmarshalJSON(data))
@@ -133,10 +141,10 @@ func easyjson10eb023eEncodeGithubComVungleVungoOpenrtb(out *jwriter.Writer, in B
 		out.RawString(prefix)
 		out.String(string(in.CustomData))
 	}
-	if in.NoBidReason != 0 {
+	if in.NoBidReason != nil {
 		const prefix string = ",\"nbr\":"
 		out.RawString(prefix)
-		out.Int(int(in.NoBidReason))
+		out.Int(int(*in.NoBidReason))
 	}
 	if len(in.RawExtension) != 0 {
 		const prefix string = ",\"ext\":"

--- a/openrtb/bidresponse_test.go
+++ b/openrtb/bidresponse_test.go
@@ -27,7 +27,7 @@ func TestBidResponseShouldValidateInvalidNoBidReasons(t *testing.T) {
 
 	for i, test := range tests {
 		t.Logf("Testing %d...", i)
-		resp := &openrtb.BidResponse{ID: "some-id", NoBidReason: test.nbr}
+		resp := &openrtb.BidResponse{ID: "some-id", NoBidReason: test.nbr.Ref()}
 		err := resp.Validate()
 		if (test.isValid && err != nil) || (!test.isValid && err != openrtb.ErrInvalidNoBidReason) {
 			t.Errorf("Expected no-bid reason to be valid: %t, when the validation error is %v", test.isValid, err)

--- a/openrtb/export_test.go
+++ b/openrtb/export_test.go
@@ -4,7 +4,6 @@ package openrtb
 // section that is offered in nobidreason.go.
 var NoBidReasonSections = map[NoBidReason]NoBidReason{
 	NoBidReasonUnknown:           lastOpenRTBNoBidReason,
-	NoBidReasonNonZeroUnknown:    NoBidReasonNonZeroUnknown,
 	NoBidReasonResponseTimeout:   lastVungleExchangeNoBidReason,
 	NoBidReasonVungleNoCampaigns: lastVungleNoBidReason,
 }

--- a/openrtb/export_test.go
+++ b/openrtb/export_test.go
@@ -4,6 +4,7 @@ package openrtb
 // section that is offered in nobidreason.go.
 var NoBidReasonSections = map[NoBidReason]NoBidReason{
 	NoBidReasonUnknown:           lastOpenRTBNoBidReason,
+	NoBidReasonNonZeroUnknown:    NoBidReasonNonZeroUnknown,
 	NoBidReasonResponseTimeout:   lastVungleExchangeNoBidReason,
 	NoBidReasonVungleNoCampaigns: lastVungleNoBidReason,
 }

--- a/openrtb/nobidreason.go
+++ b/openrtb/nobidreason.go
@@ -44,6 +44,10 @@ const (
 	lastOpenRTBNoBidReason       NoBidReason = 11
 )
 
+// NoBidReasonNonZeroUnknown is customized non-zero unknown error.
+// This is more safe than NoBidReasonUnknown, because the zero value can easily be confused with the default value of int.
+const NoBidReasonNonZeroUnknown NoBidReason = 12
+
 // Custom no-bid reasons reserved by a Vungle ad exchange server, from 10000 - 10999.
 //
 // NOTE: Don't rearrange the order. Add new ones to the bottom, above lastVungleExchangeNoBidReason,
@@ -118,6 +122,8 @@ var NoBidReasonNames = map[NoBidReason]string{
 	NoBidReasonUnmatchedUser:     "NO_BID_UNMATCHED_USER",
 	NoBidReasonDailyReaderCapMet: "NO_BID_DAILY_READER_CAP_MET",
 	NoBidReasonDailyDomainCapMet: "NO_BID_DAILY_DOMAIN_CAP_MET",
+
+	NoBidReasonNonZeroUnknown: "NO_BID_NON_ZERO_UNKNOWN",
 
 	NoBidReasonResponseTimeout:       "NO_BID_RESPONSE_TIMEOUT",
 	NoBidReasonRequestError:          "NO_BID_REQUEST_ERROR",

--- a/openrtb/nobidreason.go
+++ b/openrtb/nobidreason.go
@@ -24,6 +24,11 @@ func (n NoBidReason) Validate() error {
 	return nil
 }
 
+// Ref returns a pointer to copy of NoBidReason.
+func (n NoBidReason) Ref() *NoBidReason {
+	return &n
+}
+
 // Standard no-bid reasons specified by OpenRTB 2.5.
 // See https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf.
 //
@@ -43,10 +48,6 @@ const (
 	NoBidReasonDailyDomainCapMet NoBidReason = 10 // Daily Domain Cap Met
 	lastOpenRTBNoBidReason       NoBidReason = 11
 )
-
-// NoBidReasonNonZeroUnknown is customized non-zero unknown error.
-// This is more safe than NoBidReasonUnknown, because the zero value can easily be confused with the default value of int.
-const NoBidReasonNonZeroUnknown NoBidReason = 12
 
 // Custom no-bid reasons reserved by a Vungle ad exchange server, from 10000 - 10999.
 //
@@ -122,8 +123,6 @@ var NoBidReasonNames = map[NoBidReason]string{
 	NoBidReasonUnmatchedUser:     "NO_BID_UNMATCHED_USER",
 	NoBidReasonDailyReaderCapMet: "NO_BID_DAILY_READER_CAP_MET",
 	NoBidReasonDailyDomainCapMet: "NO_BID_DAILY_DOMAIN_CAP_MET",
-
-	NoBidReasonNonZeroUnknown: "NO_BID_NON_ZERO_UNKNOWN",
 
 	NoBidReasonResponseTimeout:       "NO_BID_RESPONSE_TIMEOUT",
 	NoBidReasonRequestError:          "NO_BID_REQUEST_ERROR",

--- a/openrtb/openrtbutil/client_test.go
+++ b/openrtb/openrtbutil/client_test.go
@@ -300,7 +300,7 @@ func TestClientHandleNoBid(t *testing.T) {
 
 		if err, ok := c.handleNoBid(resp).(NoBidError); !ok || err == nil {
 			t.Error("handleNoBid should return a NoBidError.")
-		} else if err.Reason() != test.nbr {
+		} else if err.Reason() == nil || *err.Reason() != test.nbr {
 			t.Errorf("Expected no bid with reason %v instead of %v.", test.nbr, err.Reason())
 		}
 

--- a/openrtb/openrtbutil/nobiderror.go
+++ b/openrtb/openrtbutil/nobiderror.go
@@ -17,7 +17,7 @@ type NoBidError interface {
 	// Reason method returns the reason to why there is a no bid response. Reason may summarize no-bid
 	// reasons to a set of non-standard ones for reason that cannot be described by the standard set
 	// of reasons specified in the OpenRTB spec.
-	Reason() openrtb.NoBidReason
+	Reason() *openrtb.NoBidReason
 
 	// Err method returns a non-nil error when the no bid reason was because of this underlying error.
 	Err() error
@@ -46,27 +46,27 @@ func (n *nobid) Response() *openrtb.BidResponse {
 	return n.br
 }
 
-func (n *nobid) Reason() openrtb.NoBidReason {
+func (n *nobid) Reason() *openrtb.NoBidReason {
 	if n.br != nil {
 		return n.br.NoBidReason
 	}
 
 	if n.status == http.StatusNoContent {
-		return openrtb.NoBidReasonNoContent
+		return openrtb.NoBidReasonNoContent.Ref()
 	} else if n.status > 0 {
-		return openrtb.NoBidReasonNonStandardHTTPStatus
+		return openrtb.NoBidReasonNonStandardHTTPStatus.Ref()
 	}
 
 	if n.err == openrtb.ErrInvalidHTTPContentType {
-		return openrtb.NoBidReasonInvalidHTTPHeader
+		return openrtb.NoBidReasonInvalidHTTPHeader.Ref()
 	}
 
 	if n.err != nil {
 		switch n.err.(type) {
 		case *json.SyntaxError, *json.UnmarshalTypeError, *json.UnmarshalFieldError:
-			return openrtb.NoBidReasonMalformattedPayload
+			return openrtb.NoBidReasonMalformattedPayload.Ref()
 		}
 	}
 
-	return openrtb.NoBidReasonUnknown
+	return openrtb.NoBidReasonUnknown.Ref()
 }

--- a/openrtb/openrtbutil/nobiderror_test.go
+++ b/openrtb/openrtbutil/nobiderror_test.go
@@ -11,23 +11,28 @@ import (
 func TestNobidReason(t *testing.T) {
 	tests := []struct {
 		n   *nobid
-		nbr openrtb.NoBidReason
+		nbr *openrtb.NoBidReason
 	}{
-		{&nobid{br: &openrtb.BidResponse{NoBidReason: openrtb.NoBidReasonNonHumanTraffic}}, openrtb.NoBidReasonNonHumanTraffic},
-		{&nobid{status: http.StatusNoContent}, openrtb.NoBidReasonNoContent},
-		{&nobid{status: http.StatusBadRequest}, openrtb.NoBidReasonNonStandardHTTPStatus},
-		{&nobid{err: openrtb.ErrInvalidHTTPContentType}, openrtb.NoBidReasonInvalidHTTPHeader},
-		{&nobid{err: &json.SyntaxError{}}, openrtb.NoBidReasonMalformattedPayload},
-		{&nobid{err: &json.UnmarshalTypeError{}}, openrtb.NoBidReasonMalformattedPayload},
-		{&nobid{err: &json.UnmarshalFieldError{}}, openrtb.NoBidReasonMalformattedPayload},
-		{&nobid{}, openrtb.NoBidReasonUnknown},
+		{&nobid{br: &openrtb.BidResponse{NoBidReason: openrtb.NoBidReasonNonHumanTraffic.Ref()}}, openrtb.NoBidReasonNonHumanTraffic.Ref()},
+		{&nobid{status: http.StatusNoContent}, openrtb.NoBidReasonNoContent.Ref()},
+		{&nobid{status: http.StatusBadRequest}, openrtb.NoBidReasonNonStandardHTTPStatus.Ref()},
+		{&nobid{err: openrtb.ErrInvalidHTTPContentType}, openrtb.NoBidReasonInvalidHTTPHeader.Ref()},
+		{&nobid{err: &json.SyntaxError{}}, openrtb.NoBidReasonMalformattedPayload.Ref()},
+		{&nobid{err: &json.UnmarshalTypeError{}}, openrtb.NoBidReasonMalformattedPayload.Ref()},
+		{&nobid{err: &json.UnmarshalFieldError{}}, openrtb.NoBidReasonMalformattedPayload.Ref()},
+		{&nobid{}, openrtb.NoBidReasonUnknown.Ref()},
 	}
 
 	for i, test := range tests {
 		t.Logf("Testing %d...", i)
 
-		if test.n.Reason() != test.nbr {
-			t.Errorf("Expected %v instead of %v.", test.nbr, test.n.Reason())
+		if test.n.Reason() == nil {
+			if test.nbr == nil {
+				continue
+			}
+		} else if test.nbr != nil && *test.n.Reason() == *test.nbr {
+			continue
 		}
+		t.Errorf("Expected %v instead of %v.", test.nbr, test.n.Reason())
 	}
 }


### PR DESCRIPTION
Change bid response nsr to pointer so it can correctly describe "no err" result. Because the default value 0 is used in spec to indicate unknown error.