### PR TITLE
Add publisher ext field according to openrtb spec

### DIFF
--- a/openrtb/application_easyjson.go
+++ b/openrtb/application_easyjson.go
@@ -1260,6 +1260,14 @@ func easyjsonB2e97d60DecodeGithubComVungleVungoOpenrtb1(in *jlexer.Lexer, out *P
 			}
 		case "domain":
 			out.Domain = string(in.String())
+		case "ext":
+			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
+				m.UnmarshalEasyJSON(in)
+			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
+				_ = m.UnmarshalJSON(in.Raw())
+			} else {
+				out.Extension = in.Interface()
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -1302,6 +1310,17 @@ func easyjsonB2e97d60EncodeGithubComVungleVungoOpenrtb1(out *jwriter.Writer, in 
 		const prefix string = ",\"domain\":"
 		out.RawString(prefix)
 		out.String(string(in.Domain))
+	}
+	if in.Extension != nil {
+		const prefix string = ",\"ext\":"
+		out.RawString(prefix)
+		if m, ok := in.Extension.(easyjson.Marshaler); ok {
+			m.MarshalEasyJSON(out)
+		} else if m, ok := in.Extension.(json.Marshaler); ok {
+			out.Raw(m.MarshalJSON())
+		} else {
+			out.Raw(json.Marshal(in.Extension))
+		}
 	}
 	out.RawByte('}')
 }

--- a/openrtb/bidrequest_easyjson.go
+++ b/openrtb/bidrequest_easyjson.go
@@ -2802,6 +2802,14 @@ func easyjson89fe9b30DecodeGithubComVungleVungoOpenrtb10(in *jlexer.Lexer, out *
 			}
 		case "domain":
 			out.Domain = string(in.String())
+		case "ext":
+			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
+				m.UnmarshalEasyJSON(in)
+			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
+				_ = m.UnmarshalJSON(in.Raw())
+			} else {
+				out.Extension = in.Interface()
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2844,6 +2852,17 @@ func easyjson89fe9b30EncodeGithubComVungleVungoOpenrtb10(out *jwriter.Writer, in
 		const prefix string = ",\"domain\":"
 		out.RawString(prefix)
 		out.String(string(in.Domain))
+	}
+	if in.Extension != nil {
+		const prefix string = ",\"ext\":"
+		out.RawString(prefix)
+		if m, ok := in.Extension.(easyjson.Marshaler); ok {
+			m.MarshalEasyJSON(out)
+		} else if m, ok := in.Extension.(json.Marshaler); ok {
+			out.Raw(m.MarshalJSON())
+		} else {
+			out.Raw(json.Marshal(in.Extension))
+		}
 	}
 	out.RawByte('}')
 }

--- a/openrtb/publisher.go
+++ b/openrtb/publisher.go
@@ -1,15 +1,18 @@
 package openrtb
 
+import "github.com/Vungle/vungo/internal/util"
+
 // Publisher type denotes the publisher of the media in which the ad will be displayed. Typically,
 // a publisher identifies the seller of the impression auctioned.
 // See OpenRTB 2.5 Sec 3.2.15.
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Publisher struct {
-	ID         string     `json:"id"`
-	Name       string     `json:"name,omitempty"`
-	Categories []Category `json:"cat,omitempty"`
-	Domain     string     `json:"domain,omitempty"`
+	ID         string      `json:"id"`
+	Name       string      `json:"name,omitempty"`
+	Categories []Category  `json:"cat,omitempty"`
+	Domain     string      `json:"domain,omitempty"`
+	Extension  interface{} `json:"ext,omitempty"`
 }
 
 // Copy returns a pointer to a copy of the Publisher object.
@@ -23,6 +26,7 @@ func (p *Publisher) Copy() *Publisher {
 		pubCopy.Categories = make([]Category, len(p.Categories))
 		copy(pubCopy.Categories, p.Categories)
 	}
+	pubCopy.Extension = util.DeepCopyCopiable(p.Extension)
 
 	return &pubCopy
 }

--- a/openrtb/publisher_easyjson.go
+++ b/openrtb/publisher_easyjson.go
@@ -65,6 +65,14 @@ func easyjsonE9046362DecodeGithubComVungleVungoOpenrtb(in *jlexer.Lexer, out *Pu
 			}
 		case "domain":
 			out.Domain = string(in.String())
+		case "ext":
+			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
+				m.UnmarshalEasyJSON(in)
+			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
+				_ = m.UnmarshalJSON(in.Raw())
+			} else {
+				out.Extension = in.Interface()
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -107,6 +115,17 @@ func easyjsonE9046362EncodeGithubComVungleVungoOpenrtb(out *jwriter.Writer, in P
 		const prefix string = ",\"domain\":"
 		out.RawString(prefix)
 		out.String(string(in.Domain))
+	}
+	if in.Extension != nil {
+		const prefix string = ",\"ext\":"
+		out.RawString(prefix)
+		if m, ok := in.Extension.(easyjson.Marshaler); ok {
+			m.MarshalEasyJSON(out)
+		} else if m, ok := in.Extension.(json.Marshaler); ok {
+			out.Raw(m.MarshalJSON())
+		} else {
+			out.Raw(json.Marshal(in.Extension))
+		}
 	}
 	out.RawByte('}')
 }

--- a/openrtb/testdata/publisher.json
+++ b/openrtb/testdata/publisher.json
@@ -4,5 +4,6 @@
   "cat": [
     "IAB1"
   ],
-  "domain": "spotify.com"
+  "domain": "spotify.com",
+  "ext": {"rp":{"account_id":"value"}}
 }


### PR DESCRIPTION
Currently vungo misses the ext field for publisher object. This PR will add ext field.
Please refer to https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf 3.2.15