### PR TITLE
feat(openrtb): Canonicalized openrtb version header

### DIFF
--- a/openrtb/constants.go
+++ b/openrtb/constants.go
@@ -1,4 +1,4 @@
 package openrtb
 
-// OpenRTBVersion denotes the supported the OpenRTB spec version in this package.
-const OpenRTBVersion = "2.5"
+// HeaderOpenRTBVersion25 denotes the supported the OpenRTB spec version 2.5.
+const HeaderOpenRTBVersion25 = "2.5"

--- a/openrtb/headers.go
+++ b/openrtb/headers.go
@@ -7,11 +7,11 @@ import (
 
 // HeaderOpenRTBVersion is the HTTP header name that should be included in every bid request
 // according the OpenRTB spec.
-const HeaderOpenRTBVersion = "x-openrtb-version"
+const HeaderOpenRTBVersion = "X-Openrtb-Version"
 
 // SetHeaders method sets the bid request headers required by OpenRTB spec.
 func SetHeaders(header http.Header) {
-	header.Set(HeaderOpenRTBVersion, OpenRTBVersion)
+	header.Set(HeaderOpenRTBVersion, HeaderOpenRTBVersion25)
 	header.Set("Content-Type", "application/json; charset=utf-8")
 }
 

--- a/openrtb/headers_test.go
+++ b/openrtb/headers_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSetHeaders(t *testing.T) {
 	expectedFromEmptyHeader := http.Header{
-		textproto.CanonicalMIMEHeaderKey(openrtb.HeaderOpenRTBVersion): []string{openrtb.OpenRTBVersion},
+		textproto.CanonicalMIMEHeaderKey(openrtb.HeaderOpenRTBVersion): []string{openrtb.HeaderOpenRTBVersion25},
 		"Content-Type": []string{"application/json; charset=utf-8"},
 	}
 
@@ -41,7 +41,7 @@ func TestSetHeaders(t *testing.T) {
 		{
 			http.Header{"X-Additional-Header": []string{"for test"}},
 			http.Header{
-				textproto.CanonicalMIMEHeaderKey(openrtb.HeaderOpenRTBVersion): []string{openrtb.OpenRTBVersion},
+				textproto.CanonicalMIMEHeaderKey(openrtb.HeaderOpenRTBVersion): []string{openrtb.HeaderOpenRTBVersion25},
 				"Content-Type":        []string{"application/json; charset=utf-8"},
 				"X-Additional-Header": []string{"for test"},
 			},

--- a/openrtb/openrtbutil/client_functional_test.go
+++ b/openrtb/openrtbutil/client_functional_test.go
@@ -19,8 +19,8 @@ import (
 // Caller is also responsible for closing the server when done.
 func setupTestServer(t *testing.T, fn http.HandlerFunc) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		if h := req.Header.Get(openrtb.HeaderOpenRTBVersion); h != openrtb.OpenRTBVersion {
-			t.Errorf("HTTP header for OpenRTB bid requests should contain `%s: %s` header instead of %s.", openrtb.HeaderOpenRTBVersion, openrtb.OpenRTBVersion, h)
+		if h := req.Header.Get(openrtb.HeaderOpenRTBVersion); h != openrtb.HeaderOpenRTBVersion25 {
+			t.Errorf("HTTP header for OpenRTB bid requests should contain `%s: %s` header instead of %s.", openrtb.HeaderOpenRTBVersion, openrtb.HeaderOpenRTBVersion25, h)
 		}
 
 		resp.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This PR will canonicalized the openrtb version header. By doing that we can align the  openrtb version header key with golang http lib.