### PR TITLE
feat(openrtb)[PBJ-4064]Add impression type validation

### DIFF
--- a/openrtb/bidrequest.go
+++ b/openrtb/bidrequest.go
@@ -231,6 +231,16 @@ func (r *BidRequest) Validate() error {
 		return ErrInvalidBidRequestImpressions
 	}
 
+	for _, imp := range r.Impressions {
+		if imp == nil {
+			return ErrInvalidBidRequestImpressions
+		}
+
+		if imp.Video == nil && imp.Banner == nil && imp.Native == nil {
+			return ErrInvalidBidRequestImpressions
+		}
+	}
+
 	if len(r.WhitelistedSeats) > 0 && len(r.BlocklistedSeats) > 0 {
 		return ErrInvalidBidRequestSeats
 	}


### PR DESCRIPTION
# Context

This PR adds impression type validation base on Open RTB 2.5 standard.

https://vungle.atlassian.net/browse/PBJ-4064


# Acceptance
non specific impression type will be treated as error.


# Changes

Briefly specify in bullet points the major changes introduced.
* Added impression type validation
* Added related UT cases.


