### PR TITLE
refactor(openrtb): Use json.RawMessage as the extension object part3 - Device

### DIFF
--- a/openrtb/bidrequest_easyjson.go
+++ b/openrtb/bidrequest_easyjson.go
@@ -1446,12 +1446,8 @@ func easyjson89fe9b30DecodeGithubComVungleVungoOpenrtb3(in *jlexer.Lexer, out *D
 		case "macmd5":
 			out.MACMD5 = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -1763,7 +1759,7 @@ func easyjson89fe9b30EncodeGithubComVungleVungoOpenrtb3(out *jwriter.Writer, in 
 		}
 		out.String(string(in.MACMD5))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		if first {
 			first = false
@@ -1771,13 +1767,7 @@ func easyjson89fe9b30EncodeGithubComVungleVungoOpenrtb3(out *jwriter.Writer, in 
 		} else {
 			out.RawString(prefix)
 		}
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/device.go
+++ b/openrtb/device.go
@@ -1,6 +1,10 @@
 package openrtb
 
-import "github.com/Vungle/vungo/internal/util"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/internal/util"
+)
 
 // Device object provides information pertaining to the device through which the
 // user is interacting.
@@ -267,7 +271,7 @@ type Device struct {
 	//   object
 	// Description:
 	//   Placeholder for exchange-specific extensions to OpenRTB.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }
 
 // Copy do deep copy of Device.
@@ -299,7 +303,7 @@ func (d *Device) Copy() *Device {
 		deviceCopy.SupportsJavaScript = &SupportsJavaScriptCopy
 	}
 	deviceCopy.GeoFetch = d.GeoFetch.Copy()
-	deviceCopy.Extension = util.DeepCopyCopiable(d.Extension)
+	deviceCopy.Extension = util.DeepCopyJSONRawMsg(d.Extension)
 
 	return &deviceCopy
 }

--- a/openrtb/device_easyjson.go
+++ b/openrtb/device_easyjson.go
@@ -147,12 +147,8 @@ func easyjson3073ac56DecodeGithubComVungleVungoOpenrtb(in *jlexer.Lexer, out *De
 		case "macmd5":
 			out.MACMD5 = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -464,7 +460,7 @@ func easyjson3073ac56EncodeGithubComVungleVungoOpenrtb(out *jwriter.Writer, in D
 		}
 		out.String(string(in.MACMD5))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		if first {
 			first = false
@@ -472,13 +468,7 @@ func easyjson3073ac56EncodeGithubComVungleVungoOpenrtb(out *jwriter.Writer, in D
 		} else {
 			out.RawString(prefix)
 		}
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
Update extension fields of BidRequest and its sub structs. Change them to json.RawMessage.
Here are two reason to do that:
1: Avoid the loss of precise while unmarshal data to interface{}. The build-in json and easyjson both use the type of float64 to parse a number in json string. If it is an int64 number, some information will loss.
2: Avoid the change between interface{} and specified structs. Using json.RawMessage can make sure there is only one convert from the beginning.
This is the second part of this work, update device's extension.