### PR TITLE
feat(vast): Allow streaming mime-type.

### DIFF
--- a/vast/defaults/defaults.go
+++ b/vast/defaults/defaults.go
@@ -21,4 +21,7 @@ const MaxVideoHeight = 5000
 const MinVideoHeight = 1
 
 // SupportedMineTypes is used for default supported video format.
-var SupportedMineTypes = []string{"video/mp4"}
+var SupportedMineTypes = []string{"video/mp4", "application/x-mpegURL"}
+
+// SupportedStreamingADSuffix is the only supported format suffix for streaming ad.
+const SupportedStreamingADSuffix = ".m3u8"

--- a/vast/defaults/defaults.go
+++ b/vast/defaults/defaults.go
@@ -20,8 +20,8 @@ const MaxVideoHeight = 5000
 // MinVideoHeight stands for the min video height with a default 1.
 const MinVideoHeight = 1
 
-// SupportedMineTypes is used for default supported video format.
-var SupportedMineTypes = []string{"video/mp4", "application/x-mpegURL"}
+// SupportedMimeTypes is used for default supported video format.
+var SupportedMimeTypes = []string{"video/mp4", "application/x-mpegURL"}
 
 // SupportedStreamingADSuffix is the only supported format suffix for streaming ad.
 const SupportedStreamingADSuffix = ".m3u8"

--- a/vast/vastelement/errors.go
+++ b/vast/vastelement/errors.go
@@ -64,6 +64,9 @@ var (
 	// ErrMediaFileMissDelivery error for ErrMediaFile miss Delivery.
 	ErrMediaFileMissDelivery = errors.New("ErrMediaFile miss Delivery")
 
+	// ErrMediaFileUnsupportedStreamingAD error for ErrMediaFile unsupported streaming ad.
+	ErrMediaFileUnsupportedStreamingAD = errors.New("ErrMediaFile unsupported streaming ad")
+
 	// ErrMediaFileMissMimeType error for ErrMediaFile miss MimeType.
 	ErrMediaFileMissMimeType = errors.New("ErrMediaFile miss MimeType")
 

--- a/vast/vastelement/inline_test.go
+++ b/vast/vastelement/inline_test.go
@@ -64,14 +64,14 @@ func TestOnlyOneValidMediaFileRemains(t *testing.T) {
 	}
 
 	mimeTypeIsSupported := false
-	for _, mimeType := range defaults.SupportedMineTypes {
+	for _, mimeType := range defaults.SupportedMimeTypes {
 		if mimeType == l.Creatives[0].Linear.MediaFiles[0].MimeType {
 			mimeTypeIsSupported = true
 			break
 		}
 	}
 	if !mimeTypeIsSupported {
-		t.Fatalf("MIME type %s should be in %v", l.Creatives[0].Linear.MediaFiles[0].MimeType, defaults.SupportedMineTypes)
+		t.Fatalf("MIME type %s should be in %v", l.Creatives[0].Linear.MediaFiles[0].MimeType, defaults.SupportedMimeTypes)
 	}
 }
 

--- a/vast/vastelement/mediafile.go
+++ b/vast/vastelement/mediafile.go
@@ -32,7 +32,7 @@ func (mediaFile *MediaFile) Validate(version Version) error {
 	errors := make([]error, 0)
 
 	mimeTypeIsSupported := false
-	for _, mimeType := range defaults.SupportedMineTypes {
+	for _, mimeType := range defaults.SupportedMimeTypes {
 		if mimeType == mediaFile.MimeType {
 			mimeTypeIsSupported = true
 			break

--- a/vast/vastelement/mediafile.go
+++ b/vast/vastelement/mediafile.go
@@ -1,6 +1,10 @@
 package vastelement
 
-import "github.com/Vungle/vungo/vast/defaults"
+import (
+	"path"
+
+	"github.com/Vungle/vungo/vast/defaults"
+)
 
 // MediaFile represents a <MediaFile> element that contains a reference to the creative asset in a
 // linear creative.
@@ -48,6 +52,10 @@ func (mediaFile *MediaFile) Validate(version Version) error {
 		if ok {
 			errors = append(errors, ve.Errs...)
 		}
+	}
+
+	if mediaFile.Delivery == DeliveryStreaming && path.Ext(string(mediaFile.URI)) != defaults.SupportedStreamingADSuffix {
+		errors = append(errors, ErrMediaFileUnsupportedStreamingAD)
 	}
 
 	if mediaFile.Width < 0 || mediaFile.Height < 0 {

--- a/vast/vastelement/mediafile_test.go
+++ b/vast/vastelement/mediafile_test.go
@@ -21,6 +21,7 @@ var mediaFileTests = []struct {
 	Err         error
 }{
 	{VastElement: &vastelement.MediaFile{}, File: "mediafile.xml"},
+	{VastElement: &vastelement.MediaFile{}, File: "mediafile_streaming.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileMissDelivery, File: "mediafile_without_delivery.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrUnsupportedDeliveryType, File: "mediafile_error_delivery.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileSize, File: "mediafile_error_width.xml"},
@@ -32,6 +33,7 @@ var mediaFileTests = []struct {
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileWidthTooHigh, File: "mediafile_width_too_high.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileWidthTooLow, File: "mediafile_width_too_low.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileUnsupportedMimeType, File: "mediafile_unsupported_mimetype.xml"},
+	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileUnsupportedStreamingAD, File: "mediafile_unsupported_streaming_mediafile.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaMinBitrateLessThanZero, File: "mediafile_err_minbitrate.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaMaxBitrateLessThanZero, File: "mediafile_err_maxbitrate.xml"},
 }

--- a/vast/vastelement/testdata/mediafile_streaming.xml
+++ b/vast/vastelement/testdata/mediafile_streaming.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MediaFile
+    id="some-id"
+    delivery="streaming"
+    type="application/x-mpegURL"
+    codec="H-264"
+    bitrate="256"
+    minBitrate="488"
+    maxBitrate="900"
+    width="8"
+    height="16"
+    scalable="true"
+    maintainAspectRatio="true"
+    apiFramework="Vungle Exchange"><![CDATA[http://link/to/the/video.m3u8]]></MediaFile>

--- a/vast/vastelement/testdata/mediafile_unsupported_streaming_mediafile.xml
+++ b/vast/vastelement/testdata/mediafile_unsupported_streaming_mediafile.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MediaFile
+    id="some-id"
+    delivery="streaming"
+    type="application/x-mpegURL"
+    codec="H-264"
+    bitrate="256"
+    minBitrate="488"
+    maxBitrate="900"
+    width="8"
+    height="16"
+    scalable="true"
+    maintainAspectRatio="true"
+    apiFramework="Vungle Exchange"><![CDATA[http://link/to/the/streamingad]]></MediaFile>


### PR DESCRIPTION
This PR adds support for streaming mime-types(`application/x-mpegURL`).
It also adds validation to only accept streaming ad URI with `.m3u8` suffix
