### PR TITLE
fix(videolength)[PBJ-6230]: loose the video length check

### DIFF
--- a/vast/defaults/defaults.go
+++ b/vast/defaults/defaults.go
@@ -3,7 +3,7 @@ package defaults
 import "time"
 
 // MaxVideoDuration stands for the max video duration with a default of 60 seconds.
-const MaxVideoDuration = 60 * time.Second
+const MaxVideoDuration = 120 * time.Second
 
 // MinVideoDuration stands for the min video duration with a default of 1 second.
 const MinVideoDuration = 1 * time.Second


### PR DESCRIPTION
Loose the creative video length check to 120s.