### PR TITLE
feat(*): Use RawMessage as the extension field type.

### DIFF
--- a/openrtb/native/request/asset.go
+++ b/openrtb/native/request/asset.go
@@ -1,5 +1,7 @@
 package request
 
+import "encoding/json"
+
 // Asset Object is the main container object for each asset requested or supported by Exchange on behalf of the rendering client.
 // Any object that is required is to be flagged as such.
 // Only one of the {title,img,video,data} objects should be present in each object.
@@ -17,6 +19,7 @@ package request
 // DSPs should feel confident that if they support these standards they'll be able to access most  native inventory.
 //
 // See OpenRTB Native 1.2 Sec 4.2 Asset Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Asset struct {
@@ -96,5 +99,5 @@ type Asset struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/asset_easyjson.go
+++ b/openrtb/native/request/asset_easyjson.go
@@ -83,12 +83,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 				easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest4(in, out.Data)
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -134,16 +130,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 		out.RawString(prefix)
 		easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest4(out, *in.Data)
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -195,12 +185,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest4(in *jlexer.
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -226,16 +212,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest4(out *jwrite
 		out.RawString(prefix)
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -309,12 +289,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest3(in *jlexer.
 				in.Delim(']')
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -372,16 +348,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest3(out *jwrite
 			out.RawByte(']')
 		}
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -438,12 +408,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest2(in *jlexer.
 				in.Delim(']')
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -524,7 +490,7 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest2(out *jwrite
 			out.RawByte(']')
 		}
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		if first {
 			first = false
@@ -532,13 +498,7 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest2(out *jwrite
 		} else {
 			out.RawString(prefix)
 		}
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -564,12 +524,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeRequest1(in *jlexer.
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -590,16 +546,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeRequest1(out *jwrite
 		out.RawString(prefix[1:])
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/data.go
+++ b/openrtb/native/request/data.go
@@ -1,12 +1,17 @@
 package request
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // Data Object is to be used for all non-core elements of the  native unit such as Brand Name, Ratings, Review Count, Stars, Download count, descriptions etc.
 // It is also generic for future  native elements not contemplated at the time of the writing of this document.
 // In some cases, additional recommendations are also included in the Data Asset Types table.
 //
 // See OpenRTB Native 1.2 Sec 4.6 Data Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Data struct {
@@ -41,5 +46,5 @@ type Data struct {
 	//   object
 	// Description:
 	// This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility beyond the standard defined in this specification
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/data_easyjson.go
+++ b/openrtb/native/request/data_easyjson.go
@@ -42,12 +42,8 @@ func easyjson794297d0DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -73,16 +69,10 @@ func easyjson794297d0EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 		out.RawString(prefix)
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/eventtracker.go
+++ b/openrtb/native/request/eventtracker.go
@@ -1,11 +1,16 @@
 package request
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // EventTracker object specifies the types of events the bidder can request to be tracked in the bid response, and which
-//types of tracking are available for each event type, and is included as an array in the request.
+// types of tracking are available for each event type, and is included as an array in the request.
 //
 // See OpenRTB Native 1.2 Sec 4.7 Event Trackers Request Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type EventTracker struct {
@@ -39,5 +44,5 @@ type EventTracker struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/eventtracker_easyjson.go
+++ b/openrtb/native/request/eventtracker_easyjson.go
@@ -63,12 +63,8 @@ func easyjson88abeb4cDecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 				in.Delim(']')
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -105,16 +101,10 @@ func easyjson88abeb4cEncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 			out.RawByte(']')
 		}
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/image.go
+++ b/openrtb/native/request/image.go
@@ -1,11 +1,16 @@
 package request
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // Image object to be used for all image elements of the Native ad such as Icons, Main Image, etc.
 // Recommended sizes and aspect ratios are included in the Image Asset Types section.
 //
 // See OpenRTB Native 1.2 Sec 4.4 Image Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Image struct {
@@ -93,5 +98,5 @@ type Image struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/image_easyjson.go
+++ b/openrtb/native/request/image_easyjson.go
@@ -71,12 +71,8 @@ func easyjson220accf5DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 				in.Delim(']')
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -157,7 +153,7 @@ func easyjson220accf5EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 			out.RawByte(']')
 		}
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		if first {
 			first = false
@@ -165,13 +161,7 @@ func easyjson220accf5EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 		} else {
 			out.RawString(prefix)
 		}
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/request.go
+++ b/openrtb/native/request/request.go
@@ -1,6 +1,10 @@
 package request
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // Request Object defines the native advertising opportunity available for bid via this bid
 // request. It will be included as a JSON-encoded string in the bid request’s imp.native field or as a
@@ -9,6 +13,7 @@ import "github.com/Vungle/vungo/openrtb/native"
 // with your integration docs.
 //
 // See OpenRTB Native 1.2 Sec 4.1 Native Markup Request Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Request struct {
@@ -156,5 +161,5 @@ type Request struct {
 	// Description:
 	// This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility beyond
 	//the standard defined in this specification
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/request_easyjson.go
+++ b/openrtb/native/request/request_easyjson.go
@@ -57,7 +57,7 @@ func easyjson3c9d2b01DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 				in.Delim('[')
 				if out.Assets == nil {
 					if !in.IsDelim(']') {
-						out.Assets = make([]Asset, 0, 1)
+						out.Assets = make([]Asset, 0, 0)
 					} else {
 						out.Assets = []Asset{}
 					}
@@ -102,12 +102,8 @@ func easyjson3c9d2b01DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 		case "privacy":
 			out.Privacy = int8(in.Int8())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -229,16 +225,10 @@ func easyjson3c9d2b01EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 		out.RawString(prefix)
 		out.Int8(int8(in.Privacy))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/title.go
+++ b/openrtb/native/request/title.go
@@ -1,8 +1,11 @@
 package request
 
+import "encoding/json"
+
 // Title object is to be used for title element of the Native ad.
 //
 // See OpenRTB Native 1.2 Sec 4.3 Title Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Title struct {
@@ -26,5 +29,5 @@ type Title struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/title_easyjson.go
+++ b/openrtb/native/request/title_easyjson.go
@@ -39,12 +39,8 @@ func easyjsonE7952480DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -65,16 +61,10 @@ func easyjsonE7952480EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 		out.RawString(prefix[1:])
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/request/video.go
+++ b/openrtb/native/request/video.go
@@ -1,12 +1,17 @@
 package request
 
-import "github.com/Vungle/vungo/openrtb"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb"
+)
 
 // Video object to be used for all video elements supported in the Native Ad. This corresponds to the Video object of
 // OpenRTB. Exchange implementers can impose their own specific restrictions. Here are the required attributes of the
 // Video Object. For optional attributes please refer to OpenRTB.
 //
 // See OpenRTB Native 1.2 Sec 4.5 Video Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Video struct {
@@ -62,5 +67,5 @@ type Video struct {
 	// Description:
 	// This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility beyond
 	// the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/request/video_easyjson.go
+++ b/openrtb/native/request/video_easyjson.go
@@ -88,12 +88,8 @@ func easyjson3c9ce8c3DecodeGithubComVungleVungoOpenrtbNativeRequest(in *jlexer.L
 				in.Delim(']')
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -151,16 +147,10 @@ func easyjson3c9ce8c3EncodeGithubComVungleVungoOpenrtbNativeRequest(out *jwriter
 			out.RawByte(']')
 		}
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/asset.go
+++ b/openrtb/native/response/asset.go
@@ -1,11 +1,14 @@
 package response
 
+import "encoding/json"
+
 // Asset Object is the main container object for each asset requested or supported by Exchange on behalf of the
 // rendering client. Any object that is required is to be flagged as such. Only one of the {title,img,video,data}
 // objects should be present in each object. All others should be null/absent. The id is to be unique within the
 // AssetObject array so that the response can be aligned.
 //
 // See OpenRTB Native 1.2 Sec 5.2 Asset
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Asset struct {
@@ -98,5 +101,5 @@ type Asset struct {
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
 	//   Bidders are encouraged not to use asset.ext for exchanging text assets. Use data.ext with custom type instead.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/asset_easyjson.go
+++ b/openrtb/native/response/asset_easyjson.go
@@ -92,12 +92,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 				easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse5(in, out.Link)
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -179,7 +175,7 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		}
 		easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse5(out, *in.Link)
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		if first {
 			first = false
@@ -187,13 +183,7 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		} else {
 			out.RawString(prefix)
 		}
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -268,12 +258,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse5(in *jlexer
 		case "fallback":
 			out.Fallback = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -313,16 +299,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse5(out *jwrit
 		out.RawString(prefix)
 		out.String(string(in.Fallback))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -352,12 +332,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse4(in *jlexer
 		case "value":
 			out.Value = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -399,16 +375,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse4(out *jwrit
 		}
 		out.String(string(in.Value))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -482,12 +452,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse2(in *jlexer
 		case "h":
 			out.H = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -529,16 +495,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse2(out *jwrit
 		out.RawString(prefix)
 		out.Int64(int64(in.H))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -566,12 +526,8 @@ func easyjson3b94576aDecodeGithubComVungleVungoOpenrtbNativeResponse1(in *jlexer
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -597,16 +553,10 @@ func easyjson3b94576aEncodeGithubComVungleVungoOpenrtbNativeResponse1(out *jwrit
 		out.RawString(prefix)
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/data.go
+++ b/openrtb/native/response/data.go
@@ -1,12 +1,17 @@
 package response
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // Data corresponds to the Data Object in the request, with the value filled in.  The Data Object is to be used for all
 // miscellaneous elements of the  native unit such as Brand Name, Ratings, Review Count, Stars, Downloads, Price count
 // etc. It is also generic for future  native elements not contemplated at the time of the writing of this document.
 //
 // See OpenRTB Native 1.2 Sec 5.5 Data
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Data struct {
@@ -53,5 +58,5 @@ type Data struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/data_easyjson.go
+++ b/openrtb/native/response/data_easyjson.go
@@ -44,12 +44,8 @@ func easyjson794297d0DecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 		case "value":
 			out.Value = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -91,16 +87,10 @@ func easyjson794297d0EncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		}
 		out.String(string(in.Value))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/eventtracker.go
+++ b/openrtb/native/response/eventtracker.go
@@ -12,6 +12,7 @@ import (
 // to respond with javascript trackers on other events, but the appropriateness of this is up to each buyer.
 //
 // See OpenRTB Native 1.2 Sec 5.8 Event Tracker Response Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type EventTracker struct {
@@ -65,5 +66,5 @@ type EventTracker struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/eventtracker_easyjson.go
+++ b/openrtb/native/response/eventtracker_easyjson.go
@@ -48,12 +48,8 @@ func easyjson88abeb4cDecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 				in.AddError((out.CustomData).UnmarshalJSON(data))
 			}
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -89,16 +85,10 @@ func easyjson88abeb4cEncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		out.RawString(prefix)
 		out.Raw((in.CustomData).MarshalJSON())
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/image.go
+++ b/openrtb/native/response/image.go
@@ -1,12 +1,17 @@
 package response
 
-import "github.com/Vungle/vungo/openrtb/native"
+import (
+	"encoding/json"
+
+	"github.com/Vungle/vungo/openrtb/native"
+)
 
 // Image object to be used for all image elements of the Native ad such as Icons, Main Image, etc.
 // It is recommended that if assetsurl/dcourl is being used rather than embedded assets, that an image of each
 // recommended aspect ratio (per the Image Types table) be provided forimage type 3.
 //
 // See OpenRTB Native 1.2 Sec 5.4 Image
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Image struct {
@@ -64,5 +69,5 @@ type Image struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/image_easyjson.go
+++ b/openrtb/native/response/image_easyjson.go
@@ -46,12 +46,8 @@ func easyjson220accf5DecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 		case "h":
 			out.H = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -93,16 +89,10 @@ func easyjson220accf5EncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		out.RawString(prefix)
 		out.Int64(int64(in.H))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/link.go
+++ b/openrtb/native/response/link.go
@@ -1,11 +1,14 @@
 package response
 
+import "encoding/json"
+
 // Link object is used for ‘call to action’ assets, or other links from the Native ad.
 // This Object should be associated to its peer object in the parent Asset Object or as the master link in the top level
 // Native Ad response object. When that peer object is activated (clicked) the action should take the user to the
 // location of the link.
 //
 // See OpenRTB Native 1.2 Sec 5.7 Link
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Link struct {
@@ -49,5 +52,5 @@ type Link struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/link_easyjson.go
+++ b/openrtb/native/response/link_easyjson.go
@@ -64,12 +64,8 @@ func easyjson16eb09bcDecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 		case "fallback":
 			out.Fallback = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -109,16 +105,10 @@ func easyjson16eb09bcEncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		out.RawString(prefix)
 		out.String(string(in.Fallback))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/response.go
+++ b/openrtb/native/response/response.go
@@ -1,8 +1,11 @@
 package response
 
+import "encoding/json"
+
 // Response object is the top level JSON object which identifies a native response.
 //
 // See OpenRTB Native 1.2 Sec 5.1 Native Markup Response Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Response struct {
@@ -124,5 +127,5 @@ type Response struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/response_easyjson.go
+++ b/openrtb/native/response/response_easyjson.go
@@ -118,12 +118,8 @@ func easyjson6ff3ac1dDecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 		case "privacy":
 			out.Privacy = string(in.String())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -232,16 +228,10 @@ func easyjson6ff3ac1dEncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		out.RawString(prefix)
 		out.String(string(in.Privacy))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }

--- a/openrtb/native/response/title.go
+++ b/openrtb/native/response/title.go
@@ -1,11 +1,14 @@
 package response
 
+import "encoding/json"
+
 // Title corresponds to the Title Object in the request, with the value filled in.
 // If using assetsurl or dcourl response rather than embedded asset response, it is recommended that three title objects
 // be provided, the length of each of which is less than or equal to the three recommended maximum title lengths
 // (25,90,140).
 //
 // See OpenRTB Native 1.2 Sec 5.1 Title Response Object
+//
 //go:generate easyjson $GOFILE
 //easyjson:json
 type Title struct {
@@ -39,5 +42,5 @@ type Title struct {
 	// Description:
 	//   This object is a placeholder that may contain custom JSON agreed to by the parties to support flexibility
 	//   beyond the standard defined in this specification.
-	Extension interface{} `json:"ext,omitempty"`
+	Extension json.RawMessage `json:"ext,omitempty"`
 }

--- a/openrtb/native/response/title_easyjson.go
+++ b/openrtb/native/response/title_easyjson.go
@@ -41,12 +41,8 @@ func easyjsonE7952480DecodeGithubComVungleVungoOpenrtbNativeResponse(in *jlexer.
 		case "len":
 			out.Len = int64(in.Int64())
 		case "ext":
-			if m, ok := out.Extension.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.Extension.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.Extension = in.Interface()
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Extension).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -72,16 +68,10 @@ func easyjsonE7952480EncodeGithubComVungleVungoOpenrtbNativeResponse(out *jwrite
 		out.RawString(prefix)
 		out.Int64(int64(in.Len))
 	}
-	if in.Extension != nil {
+	if len(in.Extension) != 0 {
 		const prefix string = ",\"ext\":"
 		out.RawString(prefix)
-		if m, ok := in.Extension.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.Extension.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.Extension))
-		}
+		out.Raw((in.Extension).MarshalJSON())
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
The advantage of using json.RawMessage is it delays JSON decoding for just that field.

- Use json.RawMessage to get raw JSON if we need to decode it separately
- If the field is an interface, we need to assert Extension to specific types