### PR TITLE
feat(vastelement)[VM-1863]: Add looping attr for Linear

### DIFF
--- a/vast/vastelement/linear.go
+++ b/vast/vastelement/linear.go
@@ -4,13 +4,16 @@ package vastelement
 type Linear struct {
 	// SkipOffset is time delay at which ad becomes skippable;
 	// if absent, the ad is unskippable. VAST3.0.
-	SkipOffset    *Offset       `xml:"skipoffset,attr,omitempty"`
-	IsAlternative *bool         `xml:"alternative,attr,omitempty"`
-	Duration      Duration      `xml:"Duration"`               // Required in InLine, optional in Wrapper
-	AdParameters  *AdParameters `xml:"AdParameters,omitempty"` // Type changes from string to struct in VAST3.0.
-	Trackings     []*Tracking   `xml:"TrackingEvents>Tracking,omitempty"`
-	VideoClicks   *VideoClicks  `xml:"VideoClicks,omitempty"`
-	MediaFiles    []*MediaFile  `xml:"MediaFiles>MediaFile,omitempty"`
+	SkipOffset    *Offset `xml:"skipoffset,attr,omitempty"`
+	IsAlternative *bool   `xml:"alternative,attr,omitempty"`
+	// IsLooping controls whether the video loops after it finishes playing.
+	// This is currently supported for accelerate only.
+	IsLooping    *bool         `xml:"looping,attr,omitempty"`
+	Duration     Duration      `xml:"Duration"`               // Required in InLine, optional in Wrapper
+	AdParameters *AdParameters `xml:"AdParameters,omitempty"` // Type changes from string to struct in VAST3.0.
+	Trackings    []*Tracking   `xml:"TrackingEvents>Tracking,omitempty"`
+	VideoClicks  *VideoClicks  `xml:"VideoClicks,omitempty"`
+	MediaFiles   []*MediaFile  `xml:"MediaFiles>MediaFile,omitempty"`
 
 	Extensions []*Extension `xml:"CreativeExtensions>CreativeExtension,omitempty"` // VAST3.0.
 	Icons      []*Icon      `xml:"Icons>Icon"`                                     // VAST3.0.

--- a/vast/vastelement/testdata/linear.xml
+++ b/vast/vastelement/testdata/linear.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Linear skipoffset="11:22:00.123" alternative= "true">
+<Linear skipoffset="11:22:00.123" alternative= "true" looping="true">
   <Duration>00:00:33.123</Duration>
   <AdParameters xmlEncoded="true"><![CDATA[Some ad parameters.]]></AdParameters>
   <Icons>


### PR DESCRIPTION
Liftoff can include a looping attribute on Linear in their VAST bid responses. We process this flag to allow a video to loop or not. 

User Story
-------------
https://vungle.atlassian.net/browse/VM-1863