### PR TITLE
feat(openrtb)[PBJ-7396] Support video.plcmt in bid request

### DIFF
--- a/openrtb/bidrequest_easyjson.go
+++ b/openrtb/bidrequest_easyjson.go
@@ -3618,6 +3618,8 @@ func easyjson89fe9b30DecodeGithubComVungleVungoOpenrtb14(in *jlexer.Lexer, out *
 			}
 		case "placement":
 			out.PlacementType = VideoPlacementType(in.Int())
+		case "plcmt":
+			out.PlcmtType = VideoPlcmtType(in.Int())
 		case "linearity":
 			out.Linearity = Linearity(in.Int())
 		case "skip":
@@ -3866,6 +3868,11 @@ func easyjson89fe9b30EncodeGithubComVungleVungoOpenrtb14(out *jwriter.Writer, in
 		const prefix string = ",\"placement\":"
 		out.RawString(prefix)
 		out.Int(int(in.PlacementType))
+	}
+	if in.PlcmtType != 0 {
+		const prefix string = ",\"plcmt\":"
+		out.RawString(prefix)
+		out.Int(int(in.PlcmtType))
 	}
 	if in.Linearity != 0 {
 		const prefix string = ",\"linearity\":"

--- a/openrtb/impression_easyjson.go
+++ b/openrtb/impression_easyjson.go
@@ -687,6 +687,8 @@ func easyjson7ebaa60bDecodeGithubComVungleVungoOpenrtb2(in *jlexer.Lexer, out *V
 			}
 		case "placement":
 			out.PlacementType = VideoPlacementType(in.Int())
+		case "plcmt":
+			out.PlcmtType = VideoPlcmtType(in.Int())
 		case "linearity":
 			out.Linearity = Linearity(in.Int())
 		case "skip":
@@ -935,6 +937,11 @@ func easyjson7ebaa60bEncodeGithubComVungleVungoOpenrtb2(out *jwriter.Writer, in 
 		const prefix string = ",\"placement\":"
 		out.RawString(prefix)
 		out.Int(int(in.PlacementType))
+	}
+	if in.PlcmtType != 0 {
+		const prefix string = ",\"plcmt\":"
+		out.RawString(prefix)
+		out.Int(int(in.PlcmtType))
 	}
 	if in.Linearity != 0 {
 		const prefix string = ",\"linearity\":"

--- a/openrtb/testdata/video_std.txt
+++ b/openrtb/testdata/video_std.txt
@@ -29,6 +29,9 @@ Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad pla
 placement
 integer
 Placement type for the impression. Refer to List 5.9.
+plcmt
+integer
+Video placement type for the impression. Refer to List: Plcmt Subtypes - Video in AdCOM 1.0.
 linearity
 integer
 Indicates if the impression must be linear, nonlinear, etc. If none specified, assume all are allowed. Refer to List 5.7.

--- a/openrtb/video.go
+++ b/openrtb/video.go
@@ -93,6 +93,14 @@ type Video struct {
 	PlacementType VideoPlacementType `json:"placement,omitempty"`
 
 	// Attribute:
+	//   plcmt
+	// Type:
+	//   integer
+	// Description:
+	//   Video placement type for the impression. Refer to List: Plcmt Subtypes - Video in AdCOM 1.0.
+	PlcmtType VideoPlcmtType `json:"plcmt,omitempty"`
+
+	// Attribute:
 	//   linearity
 	// Type:
 	//   integer

--- a/openrtb/video_easyjson.go
+++ b/openrtb/video_easyjson.go
@@ -120,6 +120,8 @@ func easyjson3c9ce8c3DecodeGithubComVungleVungoOpenrtb(in *jlexer.Lexer, out *Vi
 			}
 		case "placement":
 			out.PlacementType = VideoPlacementType(in.Int())
+		case "plcmt":
+			out.PlcmtType = VideoPlcmtType(in.Int())
 		case "linearity":
 			out.Linearity = Linearity(in.Int())
 		case "skip":
@@ -368,6 +370,11 @@ func easyjson3c9ce8c3EncodeGithubComVungleVungoOpenrtb(out *jwriter.Writer, in V
 		const prefix string = ",\"placement\":"
 		out.RawString(prefix)
 		out.Int(int(in.PlacementType))
+	}
+	if in.PlcmtType != 0 {
+		const prefix string = ",\"plcmt\":"
+		out.RawString(prefix)
+		out.Int(int(in.PlcmtType))
 	}
 	if in.Linearity != 0 {
 		const prefix string = ",\"linearity\":"

--- a/openrtb/videoplacementtype.go
+++ b/openrtb/videoplacementtype.go
@@ -3,6 +3,7 @@ package openrtb
 // VideoPlacementType represents the various types of video placements derived largely from the IAB
 // Digital Video Guidelines.
 // See OpenRTB 2.5 Sec 5.9.
+// Proposed removal of this list and associated attribute in 2024
 type VideoPlacementType int
 
 // VideoPlacementType enums
@@ -12,4 +13,16 @@ const (
 	VideoPlacementTypeInArticle                  VideoPlacementType = 3 // In-Article. Loads and plays dynamically between paragraphs of editorial content; existing as a standalonebranded message.
 	VideoPlacementTypeInFeed                     VideoPlacementType = 4 // In-Feed. Found in content, social, or product feeds.
 	VideoPlacementTypeInterstitialSliderFloating VideoPlacementType = 5 // Interstitial/Slider/Floating. Covers the entire or a portion of screen area, but is always on screen while displayed (i.e.cannot be scrolled out of view). Note that a full-screen interstitial (e.g., in mobile) can bedistinguished from a floating/slider unit by the imp.instl field.
+)
+
+// VideoPlcmtType represents the various types of video placements derived largely from the IAB
+// Digital Video Guidelines.
+// See AdCOM v1.0 FINAL.
+type VideoPlcmtType int
+
+const (
+	VideoPlcmtTypeInStream            VideoPlcmtType = 1 // Instream: Pre-roll, mid-roll, and post-roll ads that are played before, during or after the streaming video content that the consumer has requested. Instream video must be set to “sound on” by default at player start, or have explicitly clear user intent to watch the video content. While there may be other content surrounding the player, the video content must be the focus of the user’s visit. It should remain the primary content on the page and the only video player in-view capable of audio when playing. If the player converts to floating/sticky subsequent ad calls should accurately convey the updated player size.
+	VideoPlcmtTypeAccompanyingContent VideoPlcmtType = 2 // Accompanying Content: Pre-roll, mid-roll, and post-roll ads that are played before, during, or after streaming video content. The video player loads and plays before, between, or after paragraphs of text or graphical content, and starts playing only when it enters the viewport. Accompanying content should only start playback upon entering the viewport. It may convert to a floating/sticky player as it scrolls off the page.
+	VideoPlcmtTypeInterstitial        VideoPlcmtType = 3 // Interstitial:Video ads that are played without video content. During playback, it must be the primary focus of the page and take up the majority of the viewport and cannot be scrolled out of view. This can be in placements like in-app video or slideshows.
+	VideoPlcmtTypeNoContentStandalone VideoPlcmtType = 4 // No Content/Standalone: Video ads that are played without streaming video content. This can be in placements like slideshows, native feeds, in-content or sticky/floating.
 )

--- a/openrtb/videoplacementtype.go
+++ b/openrtb/videoplacementtype.go
@@ -20,6 +20,7 @@ const (
 // See AdCOM v1.0 FINAL.
 type VideoPlcmtType int
 
+// VideoPlcmtType enums
 const (
 	VideoPlcmtTypeInStream            VideoPlcmtType = 1 // Instream: Pre-roll, mid-roll, and post-roll ads that are played before, during or after the streaming video content that the consumer has requested. Instream video must be set to “sound on” by default at player start, or have explicitly clear user intent to watch the video content. While there may be other content surrounding the player, the video content must be the focus of the user’s visit. It should remain the primary content on the page and the only video player in-view capable of audio when playing. If the player converts to floating/sticky subsequent ad calls should accurately convey the updated player size.
 	VideoPlcmtTypeAccompanyingContent VideoPlcmtType = 2 // Accompanying Content: Pre-roll, mid-roll, and post-roll ads that are played before, during, or after streaming video content. The video player loads and plays before, between, or after paragraphs of text or graphical content, and starts playing only when it enters the viewport. Accompanying content should only start playback upon entering the viewport. It may convert to a floating/sticky player as it scrolls off the page.


### PR DESCRIPTION
The release of updated definitions in AdCOM List: Plcmt Subtypes – Video and a new attribute (plcmt in [Object: Video](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectvideo)) to give publishers a way to signal video inventory in a way that more closely aligns with the updated ad format guidelines without breaking existing workstreams.

Legacy placement of video object is deprecated and proposed to remove in 2024