### PR TITLE
chore(go mod)[SSP-186]: update go version to 1.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ go:
 env:
   - GO111MODULE=on
 before_install:
-  - go get -v golang.org/x/lint/golint@v0.0.0-20201208152925-83fdc39ff7b5
-  - go get -v github.com/mailru/easyjson/...@v0.7.8-0.20220404084136-a209843d8ea9
+  - go install -v golang.org/x/lint/golint@v0.0.0-20201208152925-83fdc39ff7b5
+  - go install -v github.com/mailru/easyjson/...@v0.7.8-0.20220404084136-a209843d8ea9
   - go mod download
   - go mod graph
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
-  - 1.13.x
-  - 1.14.x
+  - 1.22.x
 
 env:
   - GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/Vungle/vungo
 
-go 1.12
+go 1.22
 
 require (
 	github.com/go-test/deep v1.0.4
 	github.com/google/go-cmp v0.5.6
 	github.com/mailru/easyjson v0.7.8-0.20220404084136-a209843d8ea9
 )
+
+require github.com/josharian/intern v1.0.0 // indirect


### PR DESCRIPTION
Updates the Go version to `1.22`

The following two places have for loops which are compiling differently:

```
[~/Developer/vungo]$ go build -gcflags=-d=loopvar=2 ./...
# github.com/Vungle/vungo/openrtb
./audio.go:238:10: loop variable companion now per-iteration, stack-allocated
./video.go:327:10: loop variable companion now per-iteration, stack-allocated
```

In both cases the existing code can be used without modification.