### PR TITLE
feat(openrtb)[AEP-56]: add LossReasonCreativeFilterNotAllowedFreeform

### DIFF
--- a/openrtb/lossreason.go
+++ b/openrtb/lossreason.go
@@ -47,6 +47,7 @@ const (
 	LossReasonCreativeFilterAdTypeExclusions            LossReason = 211 // Creative Filtered – Ad Type Exclusions
 	LossReasonCreativeFilterAnimationTooLong            LossReason = 212 // Creative Filtered – Animation Too Long
 	LossReasonCreativeFilterNotAllowedInPMPDeal         LossReason = 213 // Creative Filtered – Not Allowed in PMP Deal
+	LossReasonCreativeFilterNotAllowedFreeform          LossReason = 214 // Creative Filtered – Freeform not allowed
 )
 
 // >= 1000 Exchange specific (should be communicated to bidders a priori)


### PR DESCRIPTION
We want to no serve accelerate bids which submit freeform bid when bid request specifies that free form is not allowed. This loss reason will be used in jaeger to specify why bid was rejected  

User Story
------------
https://vungle.atlassian.net/browse/AEP-56

