### PR TITLE
feat(companion)[EF-5]: Add preload flag to Companion element

### DIFF
--- a/vast/vastelement/companion.go
+++ b/vast/vastelement/companion.go
@@ -3,8 +3,9 @@ package vastelement
 // Companion type represents a complex type that defines a companion ad.
 type Companion struct {
 	ID             string          `xml:"id,attr,omitempty"`
-	Width          int             `xml:"width,attr"`  // Required.
-	Height         int             `xml:"height,attr"` // Required.
+	Width          int             `xml:"width,attr"`             // Required.
+	Height         int             `xml:"height,attr"`            // Required.
+	Preload        int             `xml:"preload,attr,omitempty"` // This is supported for accelerate only.
 	ExpandedWidth  int             `xml:"expandedWidth,attr,omitempty"`
 	ExpandedHeight int             `xml:"expandedHeight,attr,omitempty"`
 	APIFramework   string          `xml:"apiFramework,attr,omitempty"`

--- a/vast/vastelement/testdata/companion.xml
+++ b/vast/vastelement/testdata/companion.xml
@@ -9,7 +9,8 @@
     expandedWidth="8"
     apiFramework="Vungle Exchange"
     alternative= "true"
-    adSlotId="ad-slot-id">
+    adSlotId="ad-slot-id"
+    preload="1">
   <CompanionClickThrough><![CDATA[http://clickthrough/url]]></CompanionClickThrough>
   <CompanionClickTracking><![CDATA[http://ClickTracking/url]]></CompanionClickTracking>
   <AltText><![CDATA[Alt text for HTML rendering.]]></AltText>


### PR DESCRIPTION
As part of implementing preloading for end cards, we need to modify the companion element to accept a optional preload attribute 



Design Doc
-----------
https://docs.google.com/document/d/1_8Y_XJNzLd0ffSIt-tYvINeLBQLZ97mN_6PPff8Vb3U/edit?tab=t.0#heading=h.1qldm0wc9qeq