### PR TITLE
fix: add apple hls mime type

### DIFF
--- a/vast/defaults/defaults.go
+++ b/vast/defaults/defaults.go
@@ -21,7 +21,7 @@ const MaxVideoHeight = 5000
 const MinVideoHeight = 1
 
 // SupportedMimeTypes is used for default supported video format.
-var SupportedMimeTypes = []string{"video/mp4", "application/x-mpegURL"}
+var SupportedMimeTypes = []string{"video/mp4", "application/x-mpegURL", "application/vnd.apple.mpegurl"}
 
 // SupportedStreamingADSuffix is the only supported format suffix for streaming ad.
 const SupportedStreamingADSuffix = ".m3u8"

--- a/vast/vastelement/mediafile_test.go
+++ b/vast/vastelement/mediafile_test.go
@@ -22,6 +22,7 @@ var mediaFileTests = []struct {
 }{
 	{VastElement: &vastelement.MediaFile{}, File: "mediafile.xml"},
 	{VastElement: &vastelement.MediaFile{}, File: "mediafile_streaming.xml"},
+	{VastElement: &vastelement.MediaFile{}, File: "mediafile_apple_hls.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileMissDelivery, File: "mediafile_without_delivery.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrUnsupportedDeliveryType, File: "mediafile_error_delivery.xml"},
 	{VastElement: &vastelement.MediaFile{}, Err: vastelement.ErrMediaFileSize, File: "mediafile_error_width.xml"},

--- a/vast/vastelement/testdata/mediafile_apple_hls.xml
+++ b/vast/vastelement/testdata/mediafile_apple_hls.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MediaFile
+        id="some-id"
+        delivery="streaming"
+        type="application/vnd.apple.mpegurl"
+        codec="H-264"
+        bitrate="256"
+        minBitrate="488"
+        maxBitrate="900"
+        width="8"
+        height="16"
+        scalable="true"
+        maintainAspectRatio="true"
+        apiFramework="Vungle Exchange"><![CDATA[http://link/to/the/video.m3u8]]></MediaFile>


### PR DESCRIPTION
This PR:
- updates the supported mime types to allow Apple HLS MIME Types.
- Filtering based on platform still happens in Nautilus and Jaeger (to prevent Android devices from receiving `application/vnd.apple.mpegurl` files)